### PR TITLE
Allow Python 3.7 for mini-SDK

### DIFF
--- a/src/azure-ml-rai/setup.py
+++ b/src/azure-ml-rai/setup.py
@@ -23,10 +23,10 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     package_data={},
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     install_requires=install_requires,
     classifiers=[
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.7",
         "Operating System :: OS Independent",
     ],
 )


### PR DESCRIPTION
Set the minimum required version of Python to 3.7 for the miniature SDK

Signed-off-by: Richard Edgar <riedgar@microsoft.com>