### PR TITLE
Fix for explanation gather issue

### DIFF
--- a/src/responsibleai/rai_analyse/gather_rai_insights.py
+++ b/src/responsibleai/rai_analyse/gather_rai_insights.py
@@ -20,7 +20,7 @@ from rai_component_utilities import (
     copy_insight_to_raiinsights,
     load_dashboard_info_file,
     add_properties_to_gather_run,
-    print_dir_tree
+    print_dir_tree,
 )
 
 _DASHBOARD_CONSTRUCTOR_MISMATCH = (

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -126,7 +126,7 @@ def copy_insight_to_raiinsights(
         # Put together, if we have an explanation, we need to remove
         # what's there already or we can get confused
         _logger.info("Detected explanation, removing existing directory")
-        for item in (rai_insights_dir/tool_dir_name).iterdir():
+        for item in (rai_insights_dir / tool_dir_name).iterdir():
             _logger.info("Removing directory {0}".format(str(item)))
             shutil.rmtree(item)
 

--- a/src/responsibleai/src_fetch_registered/fetch_registered.py
+++ b/src/responsibleai/src_fetch_registered/fetch_registered.py
@@ -13,8 +13,9 @@ def parse_args():
 
     # add arguments
     parser.add_argument("--model_id", type=str, help="Path to input model")
-    parser.add_argument("--model_info_output_path", type=str,
-                        help="Path to write model info JSON")
+    parser.add_argument(
+        "--model_info_output_path", type=str, help="Path to write model info JSON"
+    )
 
     args = parser.parse_args()
 

--- a/src/responsibleai/src_register/register.py
+++ b/src/responsibleai/src_register/register.py
@@ -25,9 +25,15 @@ def parse_args():
 
     # add arguments
     parser.add_argument("--model_input_path", type=str, help="Path to input model")
-    parser.add_argument("--model_info_output_path", type=str, help="Path to write model info JSON")
-    parser.add_argument("--model_base_name", type=str, help="Name of the registered model")
-    parser.add_argument("--model_name_suffix", type=int, help="Set negative to use epoch_secs")
+    parser.add_argument(
+        "--model_info_output_path", type=str, help="Path to write model info JSON"
+    )
+    parser.add_argument(
+        "--model_base_name", type=str, help="Name of the registered model"
+    )
+    parser.add_argument(
+        "--model_name_suffix", type=int, help="Set negative to use epoch_secs"
+    )
 
     # parse args
     args = parser.parse_args()
@@ -55,7 +61,9 @@ def main(args):
 
     print("Registering via MLFlow")
     mlflow.sklearn.log_model(
-        sk_model=mlflow_model, registered_model_name=registered_name, artifact_path=registered_name
+        sk_model=mlflow_model,
+        registered_model_name=registered_name,
+        artifact_path=registered_name,
     )
 
     print("Writing JSON")


### PR DESCRIPTION
There was a problem with the gathering of explanations. Basically, because even an empty `RAIInsights` object will always have a file in its explanation directory, when we copied the one we had just computed into position, the `RAIInsights` object which we were building would have two GUID directories under `explainer`. Whether or not the explanation then loaded was down to which one happened to come up first - the 'empty' explanation or the computed one. Since the Gather component then saved the loaded explanation, the resultant output port might not have the one just computed.