### PR TITLE
Convert AzureML registration script to Python

### DIFF
--- a/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
+++ b/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
@@ -144,15 +144,15 @@ steps:
     inlineScript: |
       python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_directory src/responsibleai
 
-- task: AzureCLI@2
-  displayName: Register AzureML items for Test
-  inputs:
-    azureSubscription: "${{parameters.subscriptionName}}"
-    scriptType: pscore
-    scriptLocation: scriptPath
-    scriptPath: scripts/Register-AzureML.ps1
-    arguments: test/
-    failOnStandardError: false # Since the new CLI writes stuff there
+  - task: AzureCLI@2
+    displayName: Register AzureML itemts for Test (Python)
+    inputs:
+      azureSubscription: "${{parameters.subscriptionName}}"
+      scriptType: pscore
+      scriptLocation: inlineScript
+      failOnStandardError: false # Since the new CLI writes stuff there
+      inlineScript: |
+        python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_directory test/
 
 - task: AzureCLI@2
   displayName: Run tests

--- a/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
+++ b/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
@@ -135,16 +135,6 @@ steps:
     failOnStandardError: false # Since the new CLI writes stuff there
 
 - task: AzureCLI@2
-  displayName: Register Responsible AI Components
-  inputs:
-    azureSubscription: "${{parameters.subscriptionName}}"
-    scriptType: pscore
-    scriptLocation: scriptPath
-    scriptPath: scripts/Register-AzureML.ps1
-    arguments: src/responsibleai/
-    failOnStandardError: false # Since the new CLI writes stuff there
-
-- task: AzureCLI@2
   displayName: Register Responsible AI Components (Python)
   inputs:
     azureSubscription: "${{parameters.subscriptionName}}"

--- a/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
+++ b/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
@@ -144,15 +144,15 @@ steps:
     inlineScript: |
       python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_directory src/responsibleai
 
-  - task: AzureCLI@2
-    displayName: Register AzureML itemts for Test (Python)
-    inputs:
-      azureSubscription: "${{parameters.subscriptionName}}"
-      scriptType: pscore
-      scriptLocation: inlineScript
-      failOnStandardError: false # Since the new CLI writes stuff there
-      inlineScript: |
-        python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_directory test/
+- task: AzureCLI@2
+  displayName: Register AzureML itemts for Test (Python)
+  inputs:
+    azureSubscription: "${{parameters.subscriptionName}}"
+    scriptType: pscore
+    scriptLocation: inlineScript
+    failOnStandardError: false # Since the new CLI writes stuff there
+    inlineScript: |
+      python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_directory test/
 
 - task: AzureCLI@2
   displayName: Run tests

--- a/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
+++ b/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
@@ -145,6 +145,16 @@ steps:
     failOnStandardError: false # Since the new CLI writes stuff there
 
 - task: AzureCLI@2
+  displayName: Register Responsible AI Components (Python)
+  inputs:
+    azureSubscription: "${{parameters.subscriptionName}}"
+    scriptType: pscore
+    scriptLocation: inlineScript
+    failOnStandardError: false # Since the new CLI writes stuff there
+    inlineScript: |
+      python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_path src/responsibleai
+
+- task: AzureCLI@2
   displayName: Register AzureML items for Test
   inputs:
     azureSubscription: "${{parameters.subscriptionName}}"

--- a/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
+++ b/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
@@ -145,7 +145,7 @@ steps:
       python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_directory src/responsibleai
 
 - task: AzureCLI@2
-  displayName: Register AzureML itemts for Test (Python)
+  displayName: Register AzureML items for Test (Python)
   inputs:
     azureSubscription: "${{parameters.subscriptionName}}"
     scriptType: pscore

--- a/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
+++ b/azuredevops/templates/obtain-workspace-run-tests-step-template.yaml
@@ -152,7 +152,7 @@ steps:
     scriptLocation: inlineScript
     failOnStandardError: false # Since the new CLI writes stuff there
     inlineScript: |
-      python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_path src/responsibleai
+      python scripts/register_azureml.py --workspace_config config.json --component_config component_config.json --base_directory src/responsibleai
 
 - task: AzureCLI@2
   displayName: Register AzureML items for Test

--- a/scripts/register_azureml.py
+++ b/scripts/register_azureml.py
@@ -65,6 +65,7 @@ def process_file(input_file, output_file, replacements) -> None:
 
 def process_directory(directory: Path, ml_client: MLClient, version: int) -> None:
     _logger.info("Processing: {0}".format(directory))
+    assert directory.is_absolute()
 
     registration_file = directory / REG_CONFIG_FILENAME
     reg_config = read_json_path(registration_file.resolve())

--- a/scripts/register_azureml.py
+++ b/scripts/register_azureml.py
@@ -5,27 +5,39 @@
 import argparse
 import json
 import logging
+import os
+from pathlib import Path
 from typing import Any
+
+from azure.identity import DefaultAzureCredential
+
+from azure.ml import MLClient
+from azure.ml.entities import Environment
 
 
 _logger = logging.getLogger(__file__)
 logging.basicConfig(level=logging.INFO)
 
 
-REG_CONFIG_FILENAME = 'registration_config.json'
+REG_CONFIG_FILENAME = "registration_config.json"
+ENV_KEY = "environments"
+COMP_KEY = "components"
+DATA_KEY = "data"
+SUBDIR_KEY = "nested_directories"
+
 
 def parse_args():
     # setup arg parser
     parser = argparse.ArgumentParser()
 
     # add arguments
-    parser.add_argument("--workspace_config", type=str, help="Path to workspace config.json")
+    parser.add_argument(
+        "--workspace_config", type=str, help="Path to workspace config.json"
+    )
     parser.add_argument(
         "--component_config", type=str, help="Path to component_config.json"
     )
-    parser.add_argument(
-        "--base_directory", type=str, help="Path to base directory"
-    )
+    parser.add_argument("--base_directory", type=str, help="Path to base directory")
 
     # parse args
     args = parser.parse_args()
@@ -36,14 +48,54 @@ def parse_args():
 
 def read_json_path(path: str) -> Any:
     _logger.info("Reading JSON file {0}".format(path))
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         result = json.load(f)
     return result
+
+
+def process_file(input_file, output_file, replacements):
+    with open(input_file, "r") as infile, open(output_file, "w") as outfile:
+        for line in infile:
+            for f, r in replacements.items():
+                line = line.replace(f, r)
+            outfile.write(line)
+
+
+def process_directory(directory: Path, ml_client: MLClient, version: int):
+    _logger.info("Processing: {0}".format(directory))
+
+    registration_file = directory / REG_CONFIG_FILENAME
+    reg_config = read_json_path(registration_file)
+
+    replacements = {"VERSION_REPLACEMENT_STRING": str(version)}
+
+    _logger.info("Changing directory")
+    os.chdir(directory)
+
+    if ENV_KEY in reg_config.keys():
+        for e in reg_config[ENV_KEY]:
+            _logger.info("Registering environment: {0}".format(e))
+            processed_file = e + ".processed"
+            process_file(e, processed_file, replacements)
+            curr_env = Environment.load(processed_file)
+            ml_client.environments.create_or_update(curr_env)
 
 
 def main(args):
     ws_config = read_json_path(args.workspace_config)
     component_config = read_json_path(args.component_config)
+
+    ml_client = MLClient(
+        credential=DefaultAzureCredential(exclude_shared_token_cache_credential=True),
+        subscription_id=ws_config["subscription_id"],
+        resource_group_name=ws_config["resource_group"],
+        workspace_name=ws_config["workspace_name"],
+        logging_enable=True,
+    )
+
+    version: int = component_config["version"]
+
+    process_directory(Path(args.base_directory), ml_client, version)
 
 
 if __name__ == "__main__":

--- a/scripts/register_azureml.py
+++ b/scripts/register_azureml.py
@@ -12,7 +12,7 @@ from typing import Any
 from azure.identity import DefaultAzureCredential
 
 from azure.ml import MLClient
-from azure.ml.entities import Environment
+from azure.ml.entities import Component, Environment
 
 
 _logger = logging.getLogger(__file__)
@@ -77,8 +77,22 @@ def process_directory(directory: Path, ml_client: MLClient, version: int):
             _logger.info("Registering environment: {0}".format(e))
             processed_file = e + ".processed"
             process_file(e, processed_file, replacements)
-            curr_env = Environment.load(processed_file)
+            curr_env: Environment = Environment.load(processed_file)
             ml_client.environments.create_or_update(curr_env)
+            _logger.info("Registered {0}".format(curr_env.name))
+    else:
+        _logger.info("No key for environments")
+
+    if COMP_KEY in reg_config.keys():
+        for c in reg_config[COMP_KEY]:
+            _logger.info("Registering component: {0}".format(c))
+            processed_file = c + ".processed"
+            process_file(c, processed_file, replacements)
+            curr_component: Component = Component.load(processed_file)
+            ml_client.components.create_or_update(curr_component)
+            _logger.info("Registered {0}".format(curr_component.name))
+    else:
+        _logger.info("No key for components")
 
 
 def main(args):

--- a/scripts/register_azureml.py
+++ b/scripts/register_azureml.py
@@ -67,7 +67,7 @@ def process_directory(directory: Path, ml_client: MLClient, version: int) -> Non
     _logger.info("Processing: {0}".format(directory))
 
     registration_file = directory / REG_CONFIG_FILENAME
-    reg_config = read_json_path(registration_file)
+    reg_config = read_json_path(registration_file.resolve())
 
     replacements = {"VERSION_REPLACEMENT_STRING": str(version)}
 
@@ -116,7 +116,8 @@ def process_directory(directory: Path, ml_client: MLClient, version: int) -> Non
         _logger.info("Working through nested directories")
         for d in reg_config[SUBDIR_KEY]:
             next_dir = directory / d
-            process_directory(next_dir, ml_client, version)
+            process_directory(next_dir.resolve(), ml_client, version)
+            os.chdir(directory)
     else:
         _logger.info("No subdirectories found for {0}".format(directory))
 
@@ -135,7 +136,7 @@ def main(args):
 
     version: int = component_config["version"]
 
-    process_directory(Path(args.base_directory), ml_client, version)
+    process_directory(Path(args.base_directory).resolve(), ml_client, version)
 
 
 if __name__ == "__main__":

--- a/scripts/register_azureml.py
+++ b/scripts/register_azureml.py
@@ -1,0 +1,51 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+import argparse
+import json
+import logging
+from typing import Any
+
+
+_logger = logging.getLogger(__file__)
+logging.basicConfig(level=logging.INFO)
+
+
+REG_CONFIG_FILENAME = 'registration_config.json'
+
+def parse_args():
+    # setup arg parser
+    parser = argparse.ArgumentParser()
+
+    # add arguments
+    parser.add_argument("--workspace_config", type=str, help="Path to workspace config.json")
+    parser.add_argument(
+        "--component_config", type=str, help="Path to component_config.json"
+    )
+    parser.add_argument(
+        "--base_directory", type=str, help="Path to base directory"
+    )
+
+    # parse args
+    args = parser.parse_args()
+
+    # return args
+    return args
+
+
+def read_json_path(path: str) -> Any:
+    _logger.info("Reading JSON file {0}".format(path))
+    with open(path, 'r') as f:
+        result = json.load(f)
+    return result
+
+
+def main(args):
+    ws_config = read_json_path(args.workspace_config)
+    component_config = read_json_path(args.component_config)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/scripts/register_azureml.py
+++ b/scripts/register_azureml.py
@@ -14,7 +14,7 @@ from typing import Any
 from azure.identity import DefaultAzureCredential
 
 from azure.ml import MLClient
-from azure.ml.entities import Component, Dataset, Environment
+from azure.ml.entities import Component, Data, Environment
 
 
 _logger = logging.getLogger(__file__)
@@ -106,8 +106,8 @@ def process_directory(directory: Path, ml_client: MLClient, version: int) -> Non
                 _logger.info("Processing {0}".format(d))
                 processed_file = d + ".processed"
                 process_file(d, processed_file, replacements)
-                curr_dataset: Dataset = Dataset.load(processed_file)
-                ml_client.datasets.create_or_update(curr_dataset)
+                curr_dataset: Data = Data.load(processed_file)
+                ml_client.data.create_or_update(curr_dataset)
                 _logger.info("Registered {0}".format(curr_dataset.name))
     else:
         _logger.info("No key for datasets")


### PR DESCRIPTION
Converting the script which registers environments, components and datasets to be Python. Although Powershell is available on other platforms, if we're going to ship this, then a Python script is friendlier.