### PR TITLE
[WIP] Adjust authentication for component output download

### DIFF
--- a/examples/notebooks/User Workflow.ipynb
+++ b/examples/notebooks/User Workflow.ipynb
@@ -42,19 +42,7 @@
    "id": "7ec3192b",
    "metadata": {},
    "source": [
-    "Now create an MLClient:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d9d6e292",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "subscription_id = 'SUB_ID'\n",
-    "resource_group = 'RG_NAME'\n",
-    "workspace_name = 'WS_NAME'"
+    "Now create an `MLClient`, using a `config.json` downloaded from the Azure portal:"
    ]
   },
   {
@@ -66,10 +54,7 @@
    "source": [
     "from azure.ml import MLClient\n",
     "from azure.identity import DefaultAzureCredential\n",
-    "ml_client = MLClient(credential=DefaultAzureCredential(exclude_shared_token_cache_credential=True),\n",
-    "                     subscription_id=subscription_id,\n",
-    "                     resource_group_name=resource_group,\n",
-    "                     workspace_name=workspace_name,\n",
+    "ml_client = MLClient.from_config(credential=DefaultAzureCredential(exclude_shared_token_cache_credential=True),\n",
     "                     logging_enable=True)"
    ]
   },
@@ -130,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = '1641390832'"
+    "version_string = '1642500168'"
    ]
   },
   {
@@ -704,9 +689,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_list = list_rai_insights(ml_client, insights_pipeline_job.experiment_name)\n",
+    "experiment_name = insights_pipeline_job.experiment_name\n",
     "\n",
-    "print(insights_pipeline_job.experiment_name)\n",
+    "run_list = list_rai_insights(ml_client, experiment_name)\n",
+    "\n",
+    "# print(insights_pipeline_job.experiment_name)\n",
     "display(run_list)"
    ]
   },

--- a/src/azure-ml-rai/azure_ml_rai/_download_rai_insights.py
+++ b/src/azure-ml-rai/azure_ml_rai/_download_rai_insights.py
@@ -19,7 +19,7 @@ from azure.storage.blob import BlobServiceClient
 from azure.ml import MLClient
 
 from ._constants import OutputPortNames
-from ._utilities import _get_v1_workspace_client
+from ._utilities import _get_v1_workspace_client, _get_storage_account_key
 
 
 def _get_output_port_info(
@@ -37,26 +37,29 @@ def _get_output_port_info(
 
 
 def _download_port_files(
-    mlflow_client: MlflowClient,
+    ml_client: MLClient,
     run_id: str,
     port_name: str,
     target_directory: Path,
     credential: ChainedTokenCredential,
 ) -> None:
+    mlflow_client = MlflowClient()
     port_info = _get_output_port_info(mlflow_client, run_id, port_name)
 
     wasbs_tuple = AzureBlobArtifactRepository.parse_wasbs_uri(port_info["Uri"])
-    storage_account = wasbs_tuple[1]
+    storage_account_name = wasbs_tuple[1]
     if len(wasbs_tuple) == 4:
         account_dns_suffix = wasbs_tuple[3]
     else:
         account_dns_suffix = "blob.core.windows.net"
 
     account_url = "https://{account}.{suffix}".format(
-        account=storage_account, suffix=account_dns_suffix
+        account=storage_account_name, suffix=account_dns_suffix
     )
 
-    bsc = BlobServiceClient(account_url=account_url, credential=credential)
+    sa_key = _get_storage_account_key(ml_client, storage_account_name)
+
+    bsc = BlobServiceClient(account_url=account_url, credential=sa_key)
     abar = AzureBlobArtifactRepository(port_info["Uri"], client=bsc)
 
     # Download everything
@@ -68,13 +71,11 @@ def download_rai_insights(ml_client: MLClient, rai_insight_id: str, path: str) -
 
     mlflow.set_tracking_uri(v1_ws.get_mlflow_tracking_uri())
 
-    mlflow_client = MlflowClient()
-
     output_directory = Path(path)
     output_directory.mkdir(parents=True, exist_ok=False)
 
     _download_port_files(
-        mlflow_client,
+        ml_client,
         rai_insight_id,
         OutputPortNames.RAI_INSIGHTS_GATHER_RAIINSIGHTS_PORT,
         output_directory,

--- a/src/azure-ml-rai/azure_ml_rai/_utilities.py
+++ b/src/azure-ml-rai/azure_ml_rai/_utilities.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
+from azure.mgmt.storage import StorageManagementClient
+
 from azure.ml import MLClient
 from azureml.core import Workspace
 
@@ -14,3 +16,14 @@ def _get_v1_workspace_client(ml_client: MLClient) -> Workspace:
     v1_workspace = Workspace(subscription, rg_name, ws_name, auth=None)
 
     return v1_workspace
+
+
+def _get_storage_account_key(ml_client: MLClient, storage_account_name: str) -> str:
+    smc = StorageManagementClient(
+        credential=ml_client._credential,
+        subscription_id=ml_client._workspace_scope.subscription_id,
+    )
+
+    keys = smc.storage_accounts.list_keys(ml_client._workspace_scope.resource_group_name, storage_account_name)
+
+    return keys.keys[0].value

--- a/src/azure-ml-rai/azure_ml_rai/_utilities.py
+++ b/src/azure-ml-rai/azure_ml_rai/_utilities.py
@@ -24,6 +24,8 @@ def _get_storage_account_key(ml_client: MLClient, storage_account_name: str) -> 
         subscription_id=ml_client._workspace_scope.subscription_id,
     )
 
-    keys = smc.storage_accounts.list_keys(ml_client._workspace_scope.resource_group_name, storage_account_name)
+    keys = smc.storage_accounts.list_keys(
+        ml_client._workspace_scope.resource_group_name, storage_account_name
+    )
 
     return keys.keys[0].value

--- a/src/azure-ml-rai/setup.py
+++ b/src/azure-ml-rai/setup.py
@@ -9,7 +9,13 @@ name = "azure_ml_rai"
 
 long_description = "Figuring out client side operations for RAI components"
 
-install_requires = ["azure-ml", "azureml-core", "azureml-mlflow", "azure-mgmt-storage", "azure-storage-blob"]
+install_requires = [
+    "azure-ml",
+    "azureml-core",
+    "azureml-mlflow",
+    "azure-mgmt-storage",
+    "azure-storage-blob",
+]
 
 setuptools.setup(
     name=name,  # noqa: F821

--- a/src/azure-ml-rai/setup.py
+++ b/src/azure-ml-rai/setup.py
@@ -9,7 +9,7 @@ name = "azure_ml_rai"
 
 long_description = "Figuring out client side operations for RAI components"
 
-install_requires = ["azure-ml", "azureml-core", "azureml-mlflow"]
+install_requires = ["azure-ml", "azureml-core", "azureml-mlflow", "azure-mgmt-storage", "azure-storage-blob"]
 
 setuptools.setup(
     name=name,  # noqa: F821


### PR DESCRIPTION
Change how the component output downloader to use the storage account keys rather than the ARM credentials. This is because by default users won't have the required 'Storage Blob Data Contributor' permissions on their storage account. Of course, this change does require users to have Control Plane access to the storage account in question...