### PR TITLE
Sort workspaces

### DIFF
--- a/scripts/Obtain-Workspace.ps1
+++ b/scripts/Obtain-Workspace.ps1
@@ -43,7 +43,9 @@ function Get-RecentResourceGroups(
         }
     )
 
-    return $filtered_groups
+    $sorted_groups = $filtered_groups | Sort-Object -Descending -Property {$_.name}
+
+    return $sorted_groups
 }
 
 


### PR DESCRIPTION
Tweak the script which obtains a workspace for the builds, to ensure that they are sorted. This in turn ensures that the newest workspace will always be picked.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>