### PR TITLE
Counterfactual fix

### DIFF
--- a/src/responsibleai/component_counterfactual.yaml
+++ b/src/responsibleai/component_counterfactual.yaml
@@ -28,7 +28,7 @@ inputs:
     default: all
   feature_importance:
     type: boolean
-    default: False
+    default: True
 
 
 outputs:


### PR DESCRIPTION
Make the default value for `feature_importance` for counterfactuals match between `RAIInsights` and the component.
