### PR TITLE
Adjust output of the Constructor component

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+    "subscription_id": "589c7ae9-223e-45e3-a191-98433e0821a9",
+    "resource_group": "amlisdkv2-rg-1643896972",
+    "workspace_name": "amlisdkv21643896972"
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,0 @@
-{
-    "subscription_id": "589c7ae9-223e-45e3-a191-98433e0821a9",
-    "resource_group": "amlisdkv2-rg-1643896972",
-    "workspace_name": "amlisdkv21643896972"
-}

--- a/src/responsibleai/rai_analyse/constants.py
+++ b/src/responsibleai/rai_analyse/constants.py
@@ -6,9 +6,12 @@
 class DashboardInfo:
     MODEL_ID_KEY = "id"  # To match Model schema
     MODEL_INFO_FILENAME = "model_info.json"
+    TRAIN_FILES_DIR = "train"
+    TEST_FILES_DIR = "test"
 
     RAI_INSIGHTS_MODEL_ID_KEY = "model_id"
     RAI_INSIGHTS_RUN_ID_KEY = "rai_insights_parent_run_id"
+    RAI_INSIGHTS_CONSTRUCTOR_ARGS_KEY = "constructor_args"
     RAI_INSIGHTS_PARENT_FILENAME = "rai_insights.json"
 
 

--- a/src/responsibleai/rai_analyse/create_causal.py
+++ b/src/responsibleai/rai_analyse/create_causal.py
@@ -11,10 +11,11 @@ from shutil import copyfile
 
 from responsibleai import RAIInsights
 
+from azureml.core import Run
 
 from constants import RAIToolType, DashboardInfo
 from rai_component_utilities import (
-    load_rai_insights_from_input_port,
+    create_rai_insights_from_port_path,
     save_to_output_port,
     copy_dashboard_info_file,
 )
@@ -68,8 +69,11 @@ def parse_args():
 
 
 def main(args):
+    my_run = Run.get_context()
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
+    rai_i: RAIInsights = create_rai_insights_from_port_path(
+        my_run, args.rai_insights_dashboard
+    )
 
     # Add the causal analysis
     rai_i.causal.add(

--- a/src/responsibleai/rai_analyse/create_counterfactual.py
+++ b/src/responsibleai/rai_analyse/create_counterfactual.py
@@ -8,10 +8,11 @@ import logging
 
 from responsibleai import RAIInsights
 
+from azureml.core import Run
 
 from constants import RAIToolType
 from rai_component_utilities import (
-    load_rai_insights_from_input_port,
+    create_rai_insights_from_port_path,
     save_to_output_port,
     copy_dashboard_info_file,
 )
@@ -50,9 +51,11 @@ def parse_args():
 
 
 def main(args):
+    my_run = Run.get_context()
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
-
+    rai_i: RAIInsights = create_rai_insights_from_port_path(
+        my_run, args.rai_insights_dashboard
+    )
     # Add the counterfactual
     rai_i.counterfactual.add(
         total_CFs=args.total_CFs,

--- a/src/responsibleai/rai_analyse/create_error_analysis.py
+++ b/src/responsibleai/rai_analyse/create_error_analysis.py
@@ -8,10 +8,11 @@ import logging
 
 from responsibleai import RAIInsights
 
+from azureml.core import Run
 
 from constants import RAIToolType
 from rai_component_utilities import (
-    load_rai_insights_from_input_port,
+    create_rai_insights_from_port_path,
     save_to_output_port,
     copy_dashboard_info_file,
 )
@@ -43,8 +44,11 @@ def parse_args():
 
 
 def main(args):
+    my_run = Run.get_context()
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
+    rai_i: RAIInsights = create_rai_insights_from_port_path(
+        my_run, args.rai_insights_dashboard
+    )
 
     # Add the error analysis
     rai_i.error_analysis.add(

--- a/src/responsibleai/rai_analyse/create_explanation.py
+++ b/src/responsibleai/rai_analyse/create_explanation.py
@@ -7,10 +7,11 @@ import logging
 
 from responsibleai import RAIInsights
 
+from azureml.core import Run
 
 from constants import RAIToolType
 from rai_component_utilities import (
-    load_rai_insights_from_input_port,
+    create_rai_insights_from_port_path,
     save_to_output_port,
     copy_dashboard_info_file,
 )
@@ -35,8 +36,13 @@ def parse_args():
 
 
 def main(args):
-    # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
+
+    my_run = Run.get_context()
+
+    # Create the RAI Insights object
+    rai_i: RAIInsights = create_rai_insights_from_port_path(
+        my_run, args.rai_insights_dashboard
+    )
 
     # Add the explanation
     rai_i.explainer.add()

--- a/src/responsibleai/rai_analyse/create_rai_insights.py
+++ b/src/responsibleai/rai_analyse/create_rai_insights.py
@@ -56,9 +56,21 @@ def parse_args():
     # return args
     return args
 
+def create_constructor_arg_dict(args):
+    result=dict()
 
+    cat_col_names = get_from_args(
+        args, "categorical_column_names", custom_parser=json.loads, allow_none=True
+    )
+    class_names = get_from_args(
+        args, "classes", custom_parser=json_empty_is_none_parser, allow_none=True
+    )
 
-
+    result['target_column']=args.target_column_name
+    result['task_type']=args.task_type
+    result['categorical_features']=cat_col_names
+    result['classes']=class_names
+    result['maximum_rows_for_test']=args.maximum_rows_for_test_dataset
 
 def main(args):
 
@@ -74,26 +86,14 @@ def main(args):
     _logger.info("Loading model: {0}".format(model_id))
     model_estimator = load_mlflow_model(my_run.experiment.workspace, model_id)
 
-    _logger.info("Getting categorical columns")
-    cat_col_names = get_from_args(
-        args, "categorical_column_names", custom_parser=json.loads, allow_none=True
-    )
-
-    _logger.info("Getting classes")
-    class_names = get_from_args(
-        args, "classes", custom_parser=json_empty_is_none_parser, allow_none=True
-    )
+    constructor_args = create_constructor_arg_dict(args)
 
     _logger.info("Creating RAIInsights object")
     insights = RAIInsights(
         model=model_estimator,
         train=train_df,
         test=test_df,
-        target_column=args.target_column_name,
-        task_type=args.task_type,
-        categorical_features=cat_col_names,
-        classes=class_names,
-        maximum_rows_for_test=args.maximum_rows_for_test_dataset,
+        **constructor_args
     )
 
     _logger.info("Saving RAIInsights object")

--- a/src/responsibleai/rai_analyse/create_rai_insights.py
+++ b/src/responsibleai/rai_analyse/create_rai_insights.py
@@ -106,7 +106,7 @@ def main(args):
     output_dict = {
         DashboardInfo.RAI_INSIGHTS_RUN_ID_KEY: str(my_run.id),
         DashboardInfo.RAI_INSIGHTS_MODEL_ID_KEY: model_id,
-        DashboardInfo.RAI_INSIGHTS_CONSTRUCTOR_ARGS_KEY: constructor_args
+        DashboardInfo.RAI_INSIGHTS_CONSTRUCTOR_ARGS_KEY: constructor_args,
     }
     output_file = os.path.join(
         args.output_path, DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
@@ -117,12 +117,12 @@ def main(args):
     _logger.info("Copying train data files")
     shutil.copytree(
         src=args.train_dataset,
-        dst=os.path.join(args.output_path, DashboardInfo.TRAIN_FILES_DIR)
+        dst=os.path.join(args.output_path, DashboardInfo.TRAIN_FILES_DIR),
     )
     _logger.info("Copying test data files")
     shutil.copytree(
         src=args.test_dataset,
-        dst=os.path.join(args.output_path, DashboardInfo.TEST_FILES_DIR)
+        dst=os.path.join(args.output_path, DashboardInfo.TEST_FILES_DIR),
     )
 
 

--- a/src/responsibleai/rai_analyse/create_rai_insights.py
+++ b/src/responsibleai/rai_analyse/create_rai_insights.py
@@ -56,8 +56,14 @@ def parse_args():
     # return args
     return args
 
+
 def create_constructor_arg_dict(args):
-    result=dict()
+    """Create a kwarg dict for RAIInsights constructor
+
+    Only does the 'parameters' for the component, not the
+    input ports
+    """
+    result = dict()
 
     cat_col_names = get_from_args(
         args, "categorical_column_names", custom_parser=json.loads, allow_none=True
@@ -66,11 +72,14 @@ def create_constructor_arg_dict(args):
         args, "classes", custom_parser=json_empty_is_none_parser, allow_none=True
     )
 
-    result['target_column']=args.target_column_name
-    result['task_type']=args.task_type
-    result['categorical_features']=cat_col_names
-    result['classes']=class_names
-    result['maximum_rows_for_test']=args.maximum_rows_for_test_dataset
+    result["target_column"] = args.target_column_name
+    result["task_type"] = args.task_type
+    result["categorical_features"] = cat_col_names
+    result["classes"] = class_names
+    result["maximum_rows_for_test"] = args.maximum_rows_for_test_dataset
+
+    return result
+
 
 def main(args):
 
@@ -90,10 +99,7 @@ def main(args):
 
     _logger.info("Creating RAIInsights object")
     insights = RAIInsights(
-        model=model_estimator,
-        train=train_df,
-        test=test_df,
-        **constructor_args
+        model=model_estimator, train=train_df, test=test_df, **constructor_args
     )
 
     _logger.info("Saving RAIInsights object")

--- a/src/responsibleai/rai_analyse/gather_rai_insights.py
+++ b/src/responsibleai/rai_analyse/gather_rai_insights.py
@@ -64,6 +64,11 @@ def main(args):
         my_run = Run.get_context()
         rai_temp = create_rai_insights_from_port_path(my_run, args.constructor)
         rai_temp.save(incoming_temp_dir)
+
+        print("Savied rai_temp")
+        print_dir_tree(incoming_temp_dir)
+        print("=======")
+
         create_rai_tool_directories(incoming_dir)
         _logger.info("Saved empty RAI Insights input to temporary directory")
 

--- a/src/responsibleai/rai_analyse/gather_rai_insights.py
+++ b/src/responsibleai/rai_analyse/gather_rai_insights.py
@@ -11,12 +11,15 @@ import tempfile
 
 from typing import Dict
 
+from azureml.core import Run
+
 from responsibleai import RAIInsights
 from responsibleai.serialization_utilities import serialize_json_safe
 
 from constants import DashboardInfo, RAIToolType
 from rai_component_utilities import (
     create_rai_tool_directories,
+    create_rai_insights_from_port_path,
     copy_insight_to_raiinsights,
     load_dashboard_info_file,
     add_properties_to_gather_run,
@@ -55,66 +58,78 @@ def main(args):
     dashboard_info = load_dashboard_info_file(args.constructor)
     _logger.info("Constructor info: {0}".format(dashboard_info))
 
-    with tempfile.TemporaryDirectory() as incoming_temp_dir:
-        incoming_dir = Path(incoming_temp_dir)
-        shutil.copytree(args.constructor, incoming_dir, dirs_exist_ok=True)
-        _logger.info("Copied RAI Insights input to temporary directory")
+    with tempfile.TemporaryDirectory() as temp_rai_dir:
+        with tempfile.TemporaryDirectory() as incoming_temp_dir:
+            my_run = Run.get_context()
+            rai_temp = create_rai_insights_from_port_path(my_run, args.constructor)
+            rai_temp.save(temp_rai_dir)
 
-        create_rai_tool_directories(incoming_dir)
-        _logger.info("Copied empty RAIInsights")
+            incoming_dir = Path(incoming_temp_dir)
+            shutil.copytree(temp_rai_dir, incoming_dir, dirs_exist_ok=True)
+            _logger.info("Copied RAI Insights input to temporary directory")
 
-        insight_paths = [args.insight_1, args.insight_2, args.insight_3, args.insight_4]
+            create_rai_tool_directories(incoming_dir)
+            _logger.info("Copied empty RAIInsights")
 
-        included_tools: Dict[str, bool] = {
-            RAIToolType.CAUSAL: False,
-            RAIToolType.COUNTERFACTUAL: False,
-            RAIToolType.ERROR_ANALYSIS: False,
-            RAIToolType.EXPLANATION: False,
-        }
-        for i in range(len(insight_paths)):
-            current_insight_arg = insight_paths[i]
-            if current_insight_arg is not None:
-                current_insight_path = Path(current_insight_arg)
-                _logger.info("Checking dashboard info")
-                insight_info = load_dashboard_info_file(current_insight_path)
-                _logger.info("Insight info: {0}".format(insight_info))
+            insight_paths = [
+                args.insight_1,
+                args.insight_2,
+                args.insight_3,
+                args.insight_4,
+            ]
 
-                # Cross check against the constructor
-                if insight_info != dashboard_info:
-                    err_string = _DASHBOARD_CONSTRUCTOR_MISMATCH.format(i + 1)
-                    raise ValueError(err_string)
+            included_tools: Dict[str, bool] = {
+                RAIToolType.CAUSAL: False,
+                RAIToolType.COUNTERFACTUAL: False,
+                RAIToolType.ERROR_ANALYSIS: False,
+                RAIToolType.EXPLANATION: False,
+            }
+            for i in range(len(insight_paths)):
+                current_insight_arg = insight_paths[i]
+                if current_insight_arg is not None:
+                    current_insight_path = Path(current_insight_arg)
+                    _logger.info("Checking dashboard info")
+                    insight_info = load_dashboard_info_file(current_insight_path)
+                    _logger.info("Insight info: {0}".format(insight_info))
 
-                # Copy the data
-                _logger.info("Copying insight {0}".format(i + 1))
-                tool = copy_insight_to_raiinsights(incoming_dir, current_insight_path)
+                    # Cross check against the constructor
+                    if insight_info != dashboard_info:
+                        err_string = _DASHBOARD_CONSTRUCTOR_MISMATCH.format(i + 1)
+                        raise ValueError(err_string)
 
-                # Can only have one instance of each tool
-                if included_tools[tool]:
-                    err_string = _DUPLICATE_TOOL.format(i + 1, tool)
-                    raise ValueError(err_string)
+                    # Copy the data
+                    _logger.info("Copying insight {0}".format(i + 1))
+                    tool = copy_insight_to_raiinsights(
+                        incoming_dir, current_insight_path
+                    )
 
-                included_tools[tool] = True
-            else:
-                _logger.info("Insight {0} is None".format(i + 1))
+                    # Can only have one instance of each tool
+                    if included_tools[tool]:
+                        err_string = _DUPLICATE_TOOL.format(i + 1, tool)
+                        raise ValueError(err_string)
 
-        _logger.info("Tool summary: {0}".format(included_tools))
+                    included_tools[tool] = True
+                else:
+                    _logger.info("Insight {0} is None".format(i + 1))
 
-        rai_i = RAIInsights.load(incoming_dir)
-        _logger.info("Object loaded")
+            _logger.info("Tool summary: {0}".format(included_tools))
 
-        rai_i.save(args.dashboard)
-        _logger.info("Saved dashboard to oputput")
+            rai_i = RAIInsights.load(incoming_dir)
+            _logger.info("Object loaded")
 
-        rai_data = rai_i.get_data()
-        rai_dict = serialize_json_safe(rai_data)
-        json_filename = "dashboard.json"
-        output_path = Path(args.ux_json) / json_filename
-        with open(output_path, "w") as json_file:
-            json.dump(rai_dict, json_file)
-        _logger.info("Dashboard JSON written")
+            rai_i.save(args.dashboard)
+            _logger.info("Saved dashboard to oputput")
 
-        add_properties_to_gather_run(dashboard_info, included_tools)
-        _logger.info("Processing completed")
+            rai_data = rai_i.get_data()
+            rai_dict = serialize_json_safe(rai_data)
+            json_filename = "dashboard.json"
+            output_path = Path(args.ux_json) / json_filename
+            with open(output_path, "w") as json_file:
+                json.dump(rai_dict, json_file)
+            _logger.info("Dashboard JSON written")
+
+            add_properties_to_gather_run(dashboard_info, included_tools)
+            _logger.info("Processing completed")
 
 
 # run script

--- a/src/responsibleai/rai_analyse/gather_rai_insights.py
+++ b/src/responsibleai/rai_analyse/gather_rai_insights.py
@@ -100,9 +100,7 @@ def main(args):
 
                 # Copy the data
                 _logger.info("Copying insight {0}".format(i + 1))
-                tool = copy_insight_to_raiinsights(
-                    incoming_dir, current_insight_path
-                )
+                tool = copy_insight_to_raiinsights(incoming_dir, current_insight_path)
 
                 # Can only have one instance of each tool
                 if included_tools[tool]:

--- a/src/responsibleai/rai_analyse/gather_rai_insights.py
+++ b/src/responsibleai/rai_analyse/gather_rai_insights.py
@@ -58,78 +58,74 @@ def main(args):
     dashboard_info = load_dashboard_info_file(args.constructor)
     _logger.info("Constructor info: {0}".format(dashboard_info))
 
-    with tempfile.TemporaryDirectory() as temp_rai_dir:
-        with tempfile.TemporaryDirectory() as incoming_temp_dir:
-            my_run = Run.get_context()
-            rai_temp = create_rai_insights_from_port_path(my_run, args.constructor)
-            rai_temp.save(temp_rai_dir)
+    with tempfile.TemporaryDirectory() as incoming_temp_dir:
+        incoming_dir = Path(incoming_temp_dir)
 
-            incoming_dir = Path(incoming_temp_dir)
-            shutil.copytree(temp_rai_dir, incoming_dir, dirs_exist_ok=True)
-            _logger.info("Copied RAI Insights input to temporary directory")
+        my_run = Run.get_context()
+        rai_temp = create_rai_insights_from_port_path(my_run, args.constructor)
+        rai_temp.save(incoming_temp_dir)
+        create_rai_tool_directories(incoming_dir)
+        _logger.info("Saved empty RAI Insights input to temporary directory")
 
-            create_rai_tool_directories(incoming_dir)
-            _logger.info("Copied empty RAIInsights")
+        insight_paths = [
+            args.insight_1,
+            args.insight_2,
+            args.insight_3,
+            args.insight_4,
+        ]
 
-            insight_paths = [
-                args.insight_1,
-                args.insight_2,
-                args.insight_3,
-                args.insight_4,
-            ]
+        included_tools: Dict[str, bool] = {
+            RAIToolType.CAUSAL: False,
+            RAIToolType.COUNTERFACTUAL: False,
+            RAIToolType.ERROR_ANALYSIS: False,
+            RAIToolType.EXPLANATION: False,
+        }
+        for i in range(len(insight_paths)):
+            current_insight_arg = insight_paths[i]
+            if current_insight_arg is not None:
+                current_insight_path = Path(current_insight_arg)
+                _logger.info("Checking dashboard info")
+                insight_info = load_dashboard_info_file(current_insight_path)
+                _logger.info("Insight info: {0}".format(insight_info))
 
-            included_tools: Dict[str, bool] = {
-                RAIToolType.CAUSAL: False,
-                RAIToolType.COUNTERFACTUAL: False,
-                RAIToolType.ERROR_ANALYSIS: False,
-                RAIToolType.EXPLANATION: False,
-            }
-            for i in range(len(insight_paths)):
-                current_insight_arg = insight_paths[i]
-                if current_insight_arg is not None:
-                    current_insight_path = Path(current_insight_arg)
-                    _logger.info("Checking dashboard info")
-                    insight_info = load_dashboard_info_file(current_insight_path)
-                    _logger.info("Insight info: {0}".format(insight_info))
+                # Cross check against the constructor
+                if insight_info != dashboard_info:
+                    err_string = _DASHBOARD_CONSTRUCTOR_MISMATCH.format(i + 1)
+                    raise ValueError(err_string)
 
-                    # Cross check against the constructor
-                    if insight_info != dashboard_info:
-                        err_string = _DASHBOARD_CONSTRUCTOR_MISMATCH.format(i + 1)
-                        raise ValueError(err_string)
+                # Copy the data
+                _logger.info("Copying insight {0}".format(i + 1))
+                tool = copy_insight_to_raiinsights(
+                    incoming_dir, current_insight_path
+                )
 
-                    # Copy the data
-                    _logger.info("Copying insight {0}".format(i + 1))
-                    tool = copy_insight_to_raiinsights(
-                        incoming_dir, current_insight_path
-                    )
+                # Can only have one instance of each tool
+                if included_tools[tool]:
+                    err_string = _DUPLICATE_TOOL.format(i + 1, tool)
+                    raise ValueError(err_string)
 
-                    # Can only have one instance of each tool
-                    if included_tools[tool]:
-                        err_string = _DUPLICATE_TOOL.format(i + 1, tool)
-                        raise ValueError(err_string)
+                included_tools[tool] = True
+            else:
+                _logger.info("Insight {0} is None".format(i + 1))
 
-                    included_tools[tool] = True
-                else:
-                    _logger.info("Insight {0} is None".format(i + 1))
+        _logger.info("Tool summary: {0}".format(included_tools))
 
-            _logger.info("Tool summary: {0}".format(included_tools))
+        rai_i = RAIInsights.load(incoming_dir)
+        _logger.info("Object loaded")
 
-            rai_i = RAIInsights.load(incoming_dir)
-            _logger.info("Object loaded")
+        rai_i.save(args.dashboard)
+        _logger.info("Saved dashboard to oputput")
 
-            rai_i.save(args.dashboard)
-            _logger.info("Saved dashboard to oputput")
+        rai_data = rai_i.get_data()
+        rai_dict = serialize_json_safe(rai_data)
+        json_filename = "dashboard.json"
+        output_path = Path(args.ux_json) / json_filename
+        with open(output_path, "w") as json_file:
+            json.dump(rai_dict, json_file)
+        _logger.info("Dashboard JSON written")
 
-            rai_data = rai_i.get_data()
-            rai_dict = serialize_json_safe(rai_data)
-            json_filename = "dashboard.json"
-            output_path = Path(args.ux_json) / json_filename
-            with open(output_path, "w") as json_file:
-                json.dump(rai_dict, json_file)
-            _logger.info("Dashboard JSON written")
-
-            add_properties_to_gather_run(dashboard_info, included_tools)
-            _logger.info("Processing completed")
+        add_properties_to_gather_run(dashboard_info, included_tools)
+        _logger.info("Processing completed")
 
 
 # run script

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -220,14 +220,12 @@ def add_properties_to_gather_run(
 def create_rai_insights_from_port_path(my_run: Run, port_path: str) -> RAIInsights:
     _logger.info("Creating RAIInsights from constructor component output")
 
-    port = Path(port_path)
-
     _logger.info("Loading data files")
-    df_train = load_dataset(port / DashboardInfo.TRAIN_FILES_DIR)
-    df_test = load_dataset(port / DashboardInfo.TEST_FILES_DIR)
+    df_train = load_dataset(os.path.join(port_path, DashboardInfo.TRAIN_FILES_DIR))
+    df_test = load_dataset(os.path.join(port_path, DashboardInfo.TEST_FILES_DIR))
 
     _logger.info("Loading config file")
-    config = load_dashboard_info_file(port)
+    config = load_dashboard_info_file(port_path)
     constructor_args = config[DashboardInfo.RAI_INSIGHTS_CONSTRUCTOR_ARGS_KEY]
 
     _logger.info("Loading model")
@@ -236,5 +234,7 @@ def create_rai_insights_from_port_path(my_run: Run, port_path: str) -> RAIInsigh
     model_estimator = load_mlflow_model(my_run.experiment.workspace, model_id)
 
     _logger.info("Creating RAIInsights object")
-    rai_i = RAIInsights(model=model_estimator, train=df_train, test=df_test, **constructor_args)
+    rai_i = RAIInsights(
+        model=model_estimator, train=df_train, test=df_test, **constructor_args
+    )
     return rai_i

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -51,9 +51,7 @@ def print_dir_tree(base_dir):
 
 
 def fetch_model_id(model_info_path: str):
-    model_info_path = os.path.join(
-        model_info_path, DashboardInfo.MODEL_INFO_FILENAME
-    )
+    model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
     with open(model_info_path, "r") as json_file:
         model_info = json.load(json_file)
     return model_info[DashboardInfo.MODEL_ID_KEY]
@@ -73,6 +71,7 @@ def load_dataset(parquet_path: str):
     print(df.dtypes)
     print(df.head(10))
     return df
+
 
 def load_dashboard_info_file(input_port_path: str) -> Dict[str, str]:
     # Load the rai_insights_dashboard file info

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -218,7 +218,7 @@ def add_properties_to_gather_run(
 
 
 def create_rai_insights_from_port_path(my_run: Run, port_path: str) -> RAIInsights:
-    _logger.info("Creating RAIInsights")
+    _logger.info("Creating RAIInsights from constructor component output")
 
     port = Path(port_path)
 
@@ -235,5 +235,6 @@ def create_rai_insights_from_port_path(my_run: Run, port_path: str) -> RAIInsigh
     _logger.info("Loading model: {0}".format(model_id))
     model_estimator = load_mlflow_model(my_run.experiment.workspace, model_id)
 
+    _logger.info("Creating RAIInsights object")
     rai_i = RAIInsights(model=model_estimator, train=df_train, test=df_test, **constructor_args)
     return rai_i

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -10,7 +10,9 @@ import shutil
 import tempfile
 import uuid
 
-from typing import Dict
+from typing import Any, Dict
+
+import pandas as pd
 
 import mlflow
 

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -218,7 +218,7 @@ def add_properties_to_gather_run(
 
 
 def create_rai_insights_from_port_path(my_run: Run, port_path: str) -> RAIInsights:
-    _logger("Creating RAIInsights")
+    _logger.info("Creating RAIInsights")
 
     port = Path(port_path)
 


### PR DESCRIPTION
Change the output of the RAI Constructor component.

Previously, the output of the Constructor was the result of calling `RAIInsights.save()`. This meant that any special handling (especially for the supplied model) would only be possible within the Constructor; thereafter, the model would be pickled and passed along to the subsequent components for use.

This changeset makes the Constructor copy its inputs (the model information file and the two datasets) to its output, and add in a JSON serialisation of the inputs parameters (such as the list of categorical features). Each individual tool component can use this to create its own `RAIInsights` object, and then work as before. The `Gather` component also requires some small changes.