### PR TITLE
Add raiwidgets as dependency for conda env

### DIFF
--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -12,5 +12,6 @@ dependencies:
     - mlflow
     - azureml-mlflow
     - responsibleai~=0.17.0
+    - raiwidgets~=0.17.0
     - azureml-dataset-runtime
     - azureml-core


### PR DESCRIPTION
This PR adds raiwidgets as dependency for conda env.
The reason is, for AML interactive dashboard, if we use the docker container inside compute instance, we have dependency on raiwidgets to run `from raiwidgets import ResponsibleAIDashboard
ResponsibleAIDashboard(rai_i)`;