### PR TITLE
Add markupsafe<=2.0.1 to aml-rai-environment list

### DIFF
--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -13,5 +13,6 @@ dependencies:
     - azureml-mlflow
     - responsibleai~=0.17.0
     - raiwidgets~=0.17.0
+    - markupsafe<=2.0.1
     - azureml-dataset-runtime
     - azureml-core

--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -13,6 +13,7 @@ dependencies:
     - azureml-mlflow
     - responsibleai~=0.17.0
     - raiwidgets~=0.17.0
+    # Limit markupsafe version is a workaround to resolve the issue from markupsafe's breaking change: https://github.com/aws/aws-sam-cli/issues/3661
     - markupsafe<=2.0.1
     - azureml-dataset-runtime
     - azureml-core


### PR DESCRIPTION
There is an issue when we run `from raiwidgets import ResponsibleAIDashboard`: `ImportError: cannot import name 'soft_unicode' from 'markupsafe' in Release 1.38.0`
![image](https://user-images.githubusercontent.com/91754176/156228606-4cc0116d-6001-4a63-b70a-447d2346266c.png)

The root cause is that, there is a breaking change for `MarkupSafe:2.1.0` where they have removed `soft_unicode`.
Release note: https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0
Downgrading markupsafe to version 2.0.1 fixes the issue. So we add markupsafe<=2.0.1 to aml-rai-environment list to resolve the error.
https://github.com/aws/aws-sam-cli/issues/3661
