### PR TITLE
Pin itsdangerous package to version 2.0.1

### DIFF
--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -15,5 +15,7 @@ dependencies:
     - raiwidgets~=0.17.0
     # Limit markupsafe version is a workaround to resolve the issue from markupsafe's breaking change: https://github.com/aws/aws-sam-cli/issues/3661
     - markupsafe<=2.0.1
+    # Workaround to fix import failure related to itsdangerous's latest release: https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous
+    - itsdangerous==2.0.1
     - azureml-dataset-runtime
     - azureml-core


### PR DESCRIPTION
This PR pins itsdangerous to version 2.0.1.
The import failure seems to be related with the latest release version of the package itsdangerous. Check the latest releases [here](https://pypi.org/project/itsdangerous/#history)
[ImportError: cannot import name 'json' from itsdangerous](https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous)