### PR TITLE
Example using Raw Data for Adult

### DIFF
--- a/requirements-dev-releasepackage.txt
+++ b/requirements-dev-releasepackage.txt
@@ -1,6 +1,7 @@
 azure-common
 --extra-index-url https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2-public
 azure-ml
+liacc-arff
 pandas
 pyarrow
 pytest

--- a/requirements-dev-releasepackage.txt
+++ b/requirements-dev-releasepackage.txt
@@ -1,7 +1,7 @@
 azure-common
 --extra-index-url https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2-public
 azure-ml
-liacc-arff
+liac-arff
 pandas
 pyarrow
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 azure-common
 --extra-index-url https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2
 azure-ml
+liacc-arff
 pandas
 pyarrow
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 azure-common
 --extra-index-url https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2
 azure-ml
-liacc-arff
+liac-arff
 pandas
 pyarrow
 pytest

--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.8
   - pip=20.0.2
   - pip:
-    - numpy==1.22.1 # Issue with np.unique
+    - numpy
     - pandas
     - pyarrow
     - scikit-learn

--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.8
   - pip=20.0.2
   - pip:
-    - numpy
+    - numpy==1.22.1 # Issue with np.unique
     - pandas
     - pyarrow
     - scikit-learn

--- a/test/components/component_train_raw_adult.yaml
+++ b/test/components/component_train_raw_adult.yaml
@@ -1,0 +1,18 @@
+$schema: http://azureml/sdk-2-0/CommandComponent.json
+name: TrainRawAdultForRAI
+display_name: Train on raw Adult Census dataset
+version: VERSION_REPLACEMENT_STRING
+type: command
+inputs:
+  training_data:
+    type: path
+outputs:
+  model_output:
+    type: path
+code:
+  local_path: ./src_adult_raw/
+environment: azureml:AML-RAI-Environment:VERSION_REPLACEMENT_STRING
+command: >-
+  python train.py
+  --training_data ${{inputs.training_data}}
+  --model_output ${{outputs.model_output}}

--- a/test/components/registration_config.json
+++ b/test/components/registration_config.json
@@ -1,6 +1,11 @@
 {
     "environments": [],
-    "components": ["component_train_logreg.yaml", "component_train_boston.yaml", "component_register_tabular.yaml"],
+    "components": [
+        "component_train_logreg.yaml",
+        "component_train_boston.yaml",
+        "component_register_tabular.yaml",
+        "component_train_raw_adult.yaml"
+    ],
     "data": [],
     "nested_directories": []
 }

--- a/test/components/src_adult_raw/train.py
+++ b/test/components/src_adult_raw/train.py
@@ -13,7 +13,7 @@ import mlflow.sklearn
 
 import pandas as pd
 
-from sklearn import svm
+from sklearn.linear_model import LogisticRegression
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
@@ -72,7 +72,12 @@ def train_model(all_data: pd.DataFrame):
         ]
     )
 
-    model_pipeline = Pipeline(steps=[("preprocess", preprocessor), ("SVM", svm.SVC())])
+    model_pipeline = Pipeline(
+        steps=[
+            ("preprocess", preprocessor),
+            ("Logistic Regressions", LogisticRegression(solver="liblinear")),
+        ]
+    )
 
     model_pipeline.fit(X, y)
     return model_pipeline

--- a/test/components/src_adult_raw/train.py
+++ b/test/components/src_adult_raw/train.py
@@ -48,7 +48,7 @@ def load_data(args) -> pd.DataFrame:
 
 
 def train_model(all_data: pd.DataFrame):
-    y = (all_data[target_column_name] == ">50K") * 1
+    y = all_data[target_column_name]
     X = all_data.drop(labels=[target_column_name], axis=1)
 
     numeric_transformer = Pipeline(

--- a/test/components/src_adult_raw/train.py
+++ b/test/components/src_adult_raw/train.py
@@ -1,0 +1,122 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+
+import argparse
+import tempfile
+import os
+import shutil
+
+import mlflow
+import mlflow.sklearn
+
+import pandas as pd
+
+from sklearn import svm
+from sklearn.compose import ColumnTransformer
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+from sklearn.compose import make_column_selector as selector
+from sklearn.pipeline import Pipeline
+
+from azureml.core import Run
+
+target_column_name = "income"
+
+
+def parse_args():
+    # setup arg parser
+    parser = argparse.ArgumentParser()
+
+    # add arguments
+    parser.add_argument("--training_data", type=str, help="Path to training data")
+    parser.add_argument("--model_output", type=str, help="Path of output model")
+
+    # parse args
+    args = parser.parse_args()
+
+    # return args
+    return args
+
+
+def load_data(args) -> pd.DataFrame:
+    print("Reading data")
+    all_data = pd.read_parquet(args.training_data)
+    print(all_data.dtypes)
+    return all_data
+
+
+def train_model(all_data: pd.DataFrame):
+    y = (all_data[target_column_name] == ">50K") * 1
+    X = all_data.drop(labels=[target_column_name], axis=1)
+
+    numeric_transformer = Pipeline(
+        steps=[
+            ("impute", SimpleImputer()),
+            ("scaler", StandardScaler()),
+        ]
+    )
+
+    categorical_transformer = Pipeline(
+        [
+            ("impute", SimpleImputer(strategy="most_frequent")),
+            ("ohe", OneHotEncoder(handle_unknown="ignore", sparse=False)),
+        ]
+    )
+
+    preprocessor = ColumnTransformer(
+        transformers=[
+            ("num", numeric_transformer, selector(dtype_exclude="category")),
+            ("cat", categorical_transformer, selector(dtype_include="category")),
+        ]
+    )
+
+    model_pipeline = Pipeline(steps=[("preprocess", preprocessor), ("SVM", svm.SVC())])
+
+    model_pipeline.fit(X, y)
+    return model_pipeline
+
+
+def main(args):
+    current_experiment = Run.get_context().experiment
+    tracking_uri = current_experiment.workspace.get_mlflow_tracking_uri()
+    print("tracking_uri: {0}".format(tracking_uri))
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment(current_experiment.name)
+
+    all_data = load_data(args)
+    sklearn_model = train_model(all_data)
+
+    # Saving model with mlflow
+    with tempfile.TemporaryDirectory() as td:
+        print("Saving model with MLFlow to temporary directory")
+        tmp_output_dir = os.path.join(td, "my_model_dir")
+        mlflow.sklearn.save_model(sk_model=sklearn_model, path=tmp_output_dir)
+
+        print("Copying MLFlow model to output path")
+        for file_name in os.listdir(tmp_output_dir):
+            print("  Copying: ", file_name)
+            # As of Python 3.8, copytree will acquire dirs_exist_ok as
+            # an option, removing the need for listdir
+            shutil.copy2(
+                src=os.path.join(tmp_output_dir, file_name),
+                dst=os.path.join(args.model_output, file_name),
+            )
+
+
+# run script
+if __name__ == "__main__":
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")
+
+    # parse args
+    args = parse_args()
+
+    # run main function
+    main(args)
+
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")

--- a/test/data/raw_adult/data_raw_adult_test.yaml
+++ b/test/data/raw_adult/data_raw_adult_test.yaml
@@ -1,0 +1,6 @@
+$schema: https://azuremlsdk2.blob.core.windows.net/latest/asset.schema.json
+name: Raw_Adult_Test_PQ
+version: VERSION_REPLACEMENT_STRING
+description: Adult Census dataset, raw. Training sample
+datastore: azureml:workspaceblobstore
+local_path: ./raw_adult_test.parquet

--- a/test/data/raw_adult/data_raw_adult_train.yaml
+++ b/test/data/raw_adult/data_raw_adult_train.yaml
@@ -1,0 +1,6 @@
+$schema: https://azuremlsdk2.blob.core.windows.net/latest/asset.schema.json
+name: Raw_Adult_Train_PQ
+version: VERSION_REPLACEMENT_STRING
+description: Adult Census dataset, raw. Training sample
+datastore: azureml:workspaceblobstore
+local_path: ./raw_adult_train.parquet

--- a/test/data/raw_adult/fetch_raw_adult.py
+++ b/test/data/raw_adult/fetch_raw_adult.py
@@ -87,7 +87,7 @@ def fetch_census_dataset():
 
     result = Bunch()
     result.data = raw_df
-    result.target = target
+    result.target = (data.target == '>50K') * 1
 
     return result
 

--- a/test/data/raw_adult/fetch_raw_adult.py
+++ b/test/data/raw_adult/fetch_raw_adult.py
@@ -88,7 +88,7 @@ def fetch_census_dataset():
 
 adult_census = fetch_census_dataset()
 
-target_feature_name = 'income'
+target_feature_name = "income"
 full_data = adult_census.data.copy()
 full_data[target_feature_name] = adult_census.target
 
@@ -96,7 +96,10 @@ print(full_data.columns)
 
 
 data_train, data_test = train_test_split(
-    full_data, test_size=1000, random_state=96132, stratify=full_data[target_feature]
+    full_data,
+    test_size=1000,
+    random_state=96132,
+    stratify=full_data[target_feature_name],
 )
 
 # Don't write out the row indices to the Parquet.....

--- a/test/data/raw_adult/fetch_raw_adult.py
+++ b/test/data/raw_adult/fetch_raw_adult.py
@@ -1,0 +1,93 @@
+import arff
+from collections import OrderedDict
+from contextlib import closing
+import gzip
+import pandas as pd
+from sklearn.utils import Bunch
+import time
+
+_categorical_columns = [
+    "workclass",
+    "education",
+    "marital-status",
+    "occupation",
+    "relationship",
+    "race",
+    "sex",
+    "native-country",
+]
+
+
+def fetch_census_dataset():
+    """Fetch the Adult Census Dataset.
+    This uses a particular URL for the Adult Census dataset. The code
+    is a simplified version of fetch_openml() in sklearn.
+    The data are copied from:
+    https://openml.org/data/v1/download/1595261.gz
+    (as of 2021-03-31)
+    """
+    try:
+        from urllib import urlretrieve
+    except ImportError:
+        from urllib.request import urlretrieve
+
+    filename = "1595261.gz"
+    data_url = "https://rainotebookscdn.blob.core.windows.net/datasets/"
+
+    remaining_attempts = 5
+    sleep_duration = 10
+    while remaining_attempts > 0:
+        try:
+            urlretrieve(data_url + filename, filename)
+
+            http_stream = gzip.GzipFile(filename=filename, mode="rb")
+
+            with closing(http_stream):
+
+                def _stream_generator(response):
+                    for line in response:
+                        yield line.decode("utf-8")
+
+                stream = _stream_generator(http_stream)
+                data = arff.load(stream)
+        except Exception as exc:  # noqa: B902
+            remaining_attempts -= 1
+            print(
+                "Error downloading dataset from {} ({} attempt(s) remaining)".format(
+                    data_url, remaining_attempts
+                )
+            )
+            print(exc)
+            time.sleep(sleep_duration)
+            sleep_duration *= 2
+            continue
+        else:
+            # dataset successfully downloaded
+            break
+    else:
+        raise Exception("Could not retrieve dataset from {}.".format(data_url))
+
+    attributes = OrderedDict(data["attributes"])
+    arff_columns = list(attributes)
+
+    raw_df = pd.DataFrame(data=data["data"], columns=arff_columns)
+
+    target_column_name = "class"
+    target = raw_df.pop(target_column_name)
+    for col_name in _categorical_columns:
+        dtype = pd.api.types.CategoricalDtype(attributes[col_name])
+        raw_df[col_name] = raw_df[col_name].astype(dtype, copy=False)
+
+    result = Bunch()
+    result.data = raw_df
+    result.target = target
+
+    return result
+
+
+adult_census = fetch_census_dataset()
+
+target_feature_name = 'income'
+adult_census.data[target_feature_name] = adult_census.target
+
+    

--- a/test/data/raw_adult/fetch_raw_adult.py
+++ b/test/data/raw_adult/fetch_raw_adult.py
@@ -133,7 +133,7 @@ adult_census = fetch_census_dataset()
 
 target_feature_name = "income"
 full_data = adult_census.data.copy()
-full_data[target_feature_name] = adult_census.target.astype("category")
+full_data[target_feature_name] = adult_census.target
 
 print(full_data.columns)
 

--- a/test/data/raw_adult/fetch_raw_adult.py
+++ b/test/data/raw_adult/fetch_raw_adult.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from contextlib import closing
 import gzip
 import pandas as pd
+from sklearn.model_selection import train_test_split
 from sklearn.utils import Bunch
 import time
 

--- a/test/data/raw_adult/fetch_raw_adult.py
+++ b/test/data/raw_adult/fetch_raw_adult.py
@@ -88,6 +88,17 @@ def fetch_census_dataset():
 adult_census = fetch_census_dataset()
 
 target_feature_name = 'income'
-adult_census.data[target_feature_name] = adult_census.target
+full_data = adult_census.data.copy()
+full_data[target_feature_name] = adult_census.target
 
-    
+print(full_data.columns)
+
+
+data_train, data_test = train_test_split(
+    full_data, test_size=1000, random_state=96132, stratify=full_data[target_feature]
+)
+
+# Don't write out the row indices to the Parquet.....
+print("Saving to files")
+data_train.to_parquet("raw_adult_train.parquet", index=False)
+data_test.to_parquet("raw_adult_test.parquet", index=False)

--- a/test/data/raw_adult/fetch_raw_adult.py
+++ b/test/data/raw_adult/fetch_raw_adult.py
@@ -87,7 +87,7 @@ def fetch_census_dataset():
 
     result = Bunch()
     result.data = raw_df
-    result.target = (data.target == '>50K') * 1
+    result.target = (target == '>50K') * 1
 
     return result
 

--- a/test/data/raw_adult/registration_config.json
+++ b/test/data/raw_adult/registration_config.json
@@ -1,0 +1,14 @@
+{
+    "environments": [],
+    "components": [],
+    "data": [
+        {
+            "script" : "fetch_raw_adult.py",
+            "data_yamls": [
+                "data_raw_adult_test.yaml",
+                "data_raw_adult_train.yaml"
+            ]
+        }
+    ],
+    "nested_directories": []
+}

--- a/test/data/registration_config.json
+++ b/test/data/registration_config.json
@@ -4,6 +4,7 @@
     "data": [],
     "nested_directories": [
         "adult",
-        "boston"
+        "boston",
+        "raw_adult"
     ]
 }

--- a/test/rai/pipeline_raw_adult_analyse.yaml
+++ b/test/rai/pipeline_raw_adult_analyse.yaml
@@ -1,0 +1,102 @@
+name: AML_RAI_Analysis_Adult_VERSION_REPLACEMENT_STRING
+experiment_name: AML_RAI_Adult_VERSION_REPLACEMENT_STRING
+type: pipeline
+
+inputs:
+  target_column_name: income
+  my_training_data:
+    dataset: azureml:Raw_Adult_Train_PQ:VERSION_REPLACEMENT_STRING
+    mode: ro_mount
+  my_test_data:
+    dataset: azureml:Raw_Adult_Test_PQ:VERSION_REPLACEMENT_STRING
+    mode: ro_mount
+
+outputs:
+  my_model_directory:
+    # datastore: azureml:workspaceblobstore
+    mode: upload
+  rai_insights_dashboard:
+    # datastore: azureml:workspaceblobstore
+    mode: upload
+  model_info:
+    # datastore: azureml:workspaceblobstore
+    mode: upload
+
+compute: azureml:cpucluster
+
+settings:
+  component_job:
+    datastore: azureml:workspaceblobstore
+    environment: azureml:AML-RAI-Environment:VERSION_REPLACEMENT_STRING
+
+jobs:
+  train-model-job:
+    type: component_job
+    component: azureml:TrainRawAdultForRAI:VERSION_REPLACEMENT_STRING
+    inputs:
+      training_data: ${{inputs.my_training_data}}
+    outputs:
+      model_output: ${{outputs.my_model_directory}}
+
+  register-model-job:
+    type: component_job
+    component: azureml:RegisterModel:VERSION_REPLACEMENT_STRING
+    inputs:
+      model_input_path: ${{jobs.train-model-job.outputs.model_output}}
+      model_base_name: raw_adult_model
+    outputs:
+      model_info_output_path: ${{outputs.model_info}}
+
+  create-rai-job:
+    type: component_job
+    component: azureml:RAIInsightsConstructor:VERSION_REPLACEMENT_STRING
+    inputs:
+      title: With just the OSS
+      task_type: classification
+      model_info_path: ${{jobs.register-model-job.outputs.model_info_output_path}}
+      train_dataset: ${{inputs.my_training_data}}
+      test_dataset: ${{inputs.my_test_data}}
+      target_column_name: ${{inputs.target_column_name}}
+     categorical_column_names: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
+    outputs:
+      rai_insights_dashboard: ${{outputs.rai_insights_dashboard}}
+
+  explain_01:
+    type: component_job
+    component: azureml:RAIInsightsExplanation:VERSION_REPLACEMENT_STRING
+    inputs:
+      comment: Some random string
+      rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
+
+  causal_01:
+    type: component_job
+    component: azureml:RAIInsightsCausal:VERSION_REPLACEMENT_STRING
+    inputs:
+      rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      treatment_features: '["Age", "Sex"]'
+      heterogeneity_features: '["Marital Status"]'
+
+  counterfactual_01:
+    type: component_job
+    component: azureml:RAIInsightsCounterfactual:VERSION_REPLACEMENT_STRING
+    inputs:
+      rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      total_CFs: 10
+      desired_class: opposite
+
+  error_analysis_01:
+    type: component_job
+    component: azureml:RAIInsightsErrorAnalysis:VERSION_REPLACEMENT_STRING
+    inputs:
+      rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      filter_features: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
+
+  gather_01:
+    type: component_job
+    component: azureml:RAIInsightsGather:VERSION_REPLACEMENT_STRING
+    inputs:
+      constructor: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      insight_1: ${{jobs.causal_01.outputs.causal}}
+      insight_2: ${{jobs.counterfactual_01.outputs.counterfactual}}
+      insight_3: ${{jobs.error_analysis_01.outputs.error_analysis}}
+      insight_4: ${{jobs.explain_01.outputs.explanation}}

--- a/test/rai/pipeline_raw_adult_analyse.yaml
+++ b/test/rai/pipeline_raw_adult_analyse.yaml
@@ -67,13 +67,13 @@ jobs:
       comment: Some random string
       rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
 
-  causal_01:
-    type: component_job
-    component: azureml:RAIInsightsCausal:VERSION_REPLACEMENT_STRING
-    inputs:
-      rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
-      treatment_features: '["age", "sex"]'
-      heterogeneity_features: '["marital-status"]'
+#  causal_01:
+#    type: component_job
+#    component: azureml:RAIInsightsCausal:VERSION_REPLACEMENT_STRING
+#    inputs:
+#      rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
+#      treatment_features: '["age", "sex"]'
+#      heterogeneity_features: '["marital-status"]'
 
   counterfactual_01:
     type: component_job
@@ -95,7 +95,7 @@ jobs:
     component: azureml:RAIInsightsGather:VERSION_REPLACEMENT_STRING
     inputs:
       constructor: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
-      insight_1: ${{jobs.causal_01.outputs.causal}}
+      # insight_1: ${{jobs.causal_01.outputs.causal}}
       insight_2: ${{jobs.counterfactual_01.outputs.counterfactual}}
       insight_3: ${{jobs.error_analysis_01.outputs.error_analysis}}
       insight_4: ${{jobs.explain_01.outputs.explanation}}

--- a/test/rai/pipeline_raw_adult_analyse.yaml
+++ b/test/rai/pipeline_raw_adult_analyse.yaml
@@ -3,7 +3,6 @@ experiment_name: AML_RAI_RAW_Adult_VERSION_REPLACEMENT_STRING
 type: pipeline
 
 inputs:
-  target_column_name: income
   my_training_data:
     dataset: azureml:Raw_Adult_Train_PQ:VERSION_REPLACEMENT_STRING
     mode: ro_mount
@@ -56,7 +55,7 @@ jobs:
       model_info_path: ${{jobs.register-model-job.outputs.model_info_output_path}}
       train_dataset: ${{inputs.my_training_data}}
       test_dataset: ${{inputs.my_test_data}}
-      target_column_name: ${{inputs.target_column_name}}
+      target_column_name: 'income'
       categorical_column_names: '["workclass", "education", "marital-status", "occupation", "relationship", "race", "sex", "native-country"]'
     outputs:
       rai_insights_dashboard: ${{outputs.rai_insights_dashboard}}

--- a/test/rai/pipeline_raw_adult_analyse.yaml
+++ b/test/rai/pipeline_raw_adult_analyse.yaml
@@ -73,8 +73,8 @@ jobs:
     component: azureml:RAIInsightsCausal:VERSION_REPLACEMENT_STRING
     inputs:
       rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
-      treatment_features: '["Age", "Sex"]'
-      heterogeneity_features: '["Marital Status"]'
+      treatment_features: '["age", "sex"]'
+      heterogeneity_features: '["marital-status"]'
 
   counterfactual_01:
     type: component_job
@@ -89,7 +89,7 @@ jobs:
     component: azureml:RAIInsightsErrorAnalysis:VERSION_REPLACEMENT_STRING
     inputs:
       rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
-      filter_features: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
+      filter_features: '["race", "sex"]'
 
   gather_01:
     type: component_job

--- a/test/rai/pipeline_raw_adult_analyse.yaml
+++ b/test/rai/pipeline_raw_adult_analyse.yaml
@@ -57,7 +57,7 @@ jobs:
       train_dataset: ${{inputs.my_training_data}}
       test_dataset: ${{inputs.my_test_data}}
       target_column_name: ${{inputs.target_column_name}}
-     categorical_column_names: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
+      categorical_column_names: '["workclass", "education", "marital-status", "occupation", "relationship", "race", "sex", "native-country"]'
     outputs:
       rai_insights_dashboard: ${{outputs.rai_insights_dashboard}}
 

--- a/test/rai/pipeline_raw_adult_analyse.yaml
+++ b/test/rai/pipeline_raw_adult_analyse.yaml
@@ -1,5 +1,5 @@
-name: AML_RAI_Analysis_Adult_VERSION_REPLACEMENT_STRING
-experiment_name: AML_RAI_Adult_VERSION_REPLACEMENT_STRING
+name: AML_RAI_Analysis_RAW_Adult_VERSION_REPLACEMENT_STRING
+experiment_name: AML_RAI_RAW_Adult_VERSION_REPLACEMENT_STRING
 type: pipeline
 
 inputs:

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -49,6 +49,18 @@ class TestRAISmoke:
 
         submit_and_wait(ml_client, pipeline_job)
 
+    def test_raw_adult_pipeline_from_yaml(self, ml_client, component_config):
+        current_dir = pathlib.Path(__file__).parent.absolute()
+        pipeline_file = current_dir / "pipeline_raw_adult_analyse.yaml"
+        pipeline_processed_file = "pipeline_raw_adult_analyse.processed.yaml"
+
+        replacements = {"VERSION_REPLACEMENT_STRING": str(component_config["version"])}
+        process_file(pipeline_file, pipeline_processed_file, replacements)
+
+        pipeline_job = Job.load(path=pipeline_processed_file)
+
+        submit_and_wait(ml_client, pipeline_job)
+
     def test_classification_pipeline_from_python(
         self, ml_client: MLClient, component_config
     ):


### PR DESCRIPTION
Port over an example using raw data in the Adult Census dataset. The `shap` version of this dataset has already processed the columns to numeric values. Since `RAIInsights` cannot currently handle missing data, we impute values before creating the AzureML datasets.