### PR TITLE
Pin immutable tag to base image

### DIFF
--- a/src/responsibleai/responsibleai-environment.yaml
+++ b/src/responsibleai/responsibleai-environment.yaml
@@ -1,5 +1,5 @@
 $schema: https://azuremlschemas.azureedge.net/latest/environment.schema.json
 name: AML-RAI-Environment
 version: VERSION_REPLACEMENT_STRING
-image: mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04
+image: mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20220303.v1
 conda_file: conda_envs/python-aml-rai.yaml


### PR DESCRIPTION
This PR add immutable tag to base image so we can reuse the derived image. Without the immutable tag, any update to the base image will invalidata the derived image name and we will not be able to pull the docker image.

For tags, we can pick any but latest from below. We picked the most recent tag: "20220303.v1"
(curl https://mcr.microsoft.com/v2/azureml/openmpi3.1.2-ubuntu18.04/tags/list).Content
{
  "name": "azureml/openmpi3.1.2-ubuntu18.04",
  "tags": [
    "20200423.v1",
    "20200723.v1",
    "20200817.v1",
    "20200821.v1",
    "20201019.v1",
    "20201113.v1",
    "20201211.v1",
    "20210104.v1",
    "20210129.v1",
    "20210220.v1",
    "20210301.v1",
    "20210507.v1",
    "20210513.v1",
    "20210531.v1",
    "20210615.v1",
    "20210701.v1",
    "20210714.v1",
    "20210727.v1",
    "20210806.v1",
    "20210906.v1",
    "20210922.v1",
    "20211005.v1",
    "20211012.v1",
    "20211029.v1",
    "20211111.v1",
    "20211124.v1",
    "20211210.v1",
    "20211221.v1",
    "20220113.v1",
    "20220127.v1",
    "20220208.v1",
    "20220218.v1",
    "20220303.v1",
    "latest"
  ]
}