### PR TITLE
Pipeline fixes for v2.1.2

### DIFF
--- a/examples/notebooks/responsibleaidashboard-housing-classification-model-debugging.ipynb
+++ b/examples/notebooks/responsibleaidashboard-housing-classification-model-debugging.ipynb
@@ -442,8 +442,8 @@
     "\n",
     "pipeline_inputs = {\n",
     "    'target_column_name': target_feature,\n",
-    "    'my_training_data': JobInput(dataset=f\"Housing_Train_from_Notebook:1\"),\n",
-    "    'my_test_data': JobInput(dataset=f\"Housing_Test_from_Notebook:1\")\n",
+    "    'my_training_data': JobInput(dataset=f\"Housing_Train_from_Notebook:1\", mode=\"download\"),\n",
+    "    'my_test_data': JobInput(dataset=f\"Housing_Test_from_Notebook:1\", mode=\"download\")\n",
     "}\n",
     "\n",
     "# Specify the training job\n",
@@ -917,7 +917,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/test/rai/pipeline_adult_analyse.yaml
+++ b/test/rai/pipeline_adult_analyse.yaml
@@ -6,10 +6,10 @@ inputs:
   target_column_name: income
   my_training_data:
     dataset: azureml:Adult_Train_PQ:VERSION_REPLACEMENT_STRING
-    mode: ro_mount
+    mode: download
   my_test_data:
     dataset: azureml:Adult_Test_PQ:VERSION_REPLACEMENT_STRING
-    mode: ro_mount
+    mode: download
 
 outputs:
   my_model_directory:

--- a/test/rai/pipeline_boston_analyse.yaml
+++ b/test/rai/pipeline_boston_analyse.yaml
@@ -6,10 +6,10 @@ inputs:
   target_column_name: 'y'
   my_training_data:
     dataset: azureml:Boston_Train_PQ:VERSION_REPLACEMENT_STRING
-    mode: ro_mount
+    mode: download
   my_test_data:
     dataset: azureml:Boston_Test_PQ:VERSION_REPLACEMENT_STRING
-    mode: ro_mount
+    mode: download
 
 outputs:
   my_model_directory:

--- a/test/rai/test_causal_component.py
+++ b/test/rai/test_causal_component.py
@@ -23,8 +23,12 @@ class TestCausalComponent:
         # Pipeline globals
         pipeline_inputs = {
             "target_column_name": "income",
-            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Adult_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Adult_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # The job to fetch the model
@@ -116,8 +120,12 @@ class TestCausalComponent:
         # Pipeline globals
         pipeline_inputs = {
             "target_column_name": "y",
-            "my_training_data": JobInput(dataset=f"Boston_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Boston_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Boston_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Boston_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # The job to fetch the model

--- a/test/rai/test_counterfactual_component.py
+++ b/test/rai/test_counterfactual_component.py
@@ -23,8 +23,12 @@ class TestCounterfactualComponent:
         # Pipeline globals
         pipeline_inputs = {
             "target_column_name": "income",
-            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Adult_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Adult_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # The job to fetch the model

--- a/test/rai/test_counterfactual_component.py
+++ b/test/rai/test_counterfactual_component.py
@@ -113,8 +113,12 @@ class TestCounterfactualComponent:
         # Pipeline globals
         pipeline_inputs = {
             "target_column_name": "y",
-            "my_training_data": JobInput(dataset=f"Boston_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Boston_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Boston_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Boston_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # The job to fetch the model

--- a/test/rai/test_erroranalysis_component.py
+++ b/test/rai/test_erroranalysis_component.py
@@ -23,8 +23,12 @@ class TestErrorAnalysisComponent:
         # Pipeline globals
         pipeline_inputs = {
             "target_column_name": "income",
-            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Adult_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Adult_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # The job to fetch the model
@@ -107,8 +111,12 @@ class TestErrorAnalysisComponent:
         # Pipeline globals
         pipeline_inputs = {
             "target_column_name": "y",
-            "my_training_data": JobInput(dataset=f"Boston_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Boston_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Boston_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Boston_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # The job to fetch the model

--- a/test/rai/test_rai_gather_errors.py
+++ b/test/rai/test_rai_gather_errors.py
@@ -23,8 +23,12 @@ class TestRAIGatherErrors:
         # Configure the global pipeline inputs:
         pipeline_inputs = {
             "target_column_name": "income",
-            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Adult_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Adult_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # Specify the training job
@@ -157,8 +161,12 @@ class TestRAIGatherErrors:
         # Pipeline globals
         pipeline_inputs = {
             "target_column_name": "income",
-            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Adult_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Adult_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # The job to fetch the model

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -58,8 +58,12 @@ class TestRAISmoke:
         # Configure the global pipeline inputs:
         pipeline_inputs = {
             "target_column_name": "income",
-            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Adult_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Adult_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # Specify the training job
@@ -201,8 +205,12 @@ class TestRAISmoke:
         # Configure the global pipeline inputs:
         pipeline_inputs = {
             "target_column_name": "income",
-            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
+            "my_training_data": JobInput(
+                dataset=f"Adult_Train_PQ:{version_string}", mode="download"
+            ),
+            "my_test_data": JobInput(
+                dataset=f"Adult_Test_PQ:{version_string}", mode="download"
+            ),
         }
 
         # Specify the training job

--- a/test/rai/test_tabular_datasets.py
+++ b/test/rai/test_tabular_datasets.py
@@ -163,7 +163,9 @@ class TestRegisterTabularDataset:
                 "ux_json": rai_gather_job.outputs.ux_json,
             }
 
-        adult_test_pq = JobInput(path=f"Adult_Test_PQ:{version_string}", mode="download")
+        adult_test_pq = JobInput(
+            path=f"Adult_Test_PQ:{version_string}", mode="download"
+        )
         rai_pipeline = use_tabular_rai(
             target_column_name="income",
             train_data_name=f"{train_tabular_base}_{epoch_secs}",

--- a/test/rai/test_tabular_datasets.py
+++ b/test/rai/test_tabular_datasets.py
@@ -163,9 +163,7 @@ class TestRegisterTabularDataset:
                 "ux_json": rai_gather_job.outputs.ux_json,
             }
 
-        adult_test_pq = ml_client.datasets.get(
-            name="Adult_Test_PQ", version=version_string
-        )
+        adult_test_pq = JobInput(path=f"Adult_Test_PQ:{version_string}", mode="download")
         rai_pipeline = use_tabular_rai(
             target_column_name="income",
             train_data_name=f"{train_tabular_base}_{epoch_secs}",


### PR DESCRIPTION
There is an issue making copies of the incoming data when the datasets are present via `ro_mount`. The files are copied via `shutil.copytree()` and something inside that code is getting confused. Since the current approach is going to be retired once `MLTable` comes online, just switch to `download` mode for now.