### PR TITLE
refine job name due to upcoming breaking change

### DIFF
--- a/test/rai/pipeline_adult_analyse.yaml
+++ b/test/rai/pipeline_adult_analyse.yaml
@@ -31,7 +31,7 @@ jobs:
     type: command
     component: azureml:register_model:VERSION_REPLACEMENT_STRING
     inputs:
-      model_input_path: ${{parent.jobs.train-model-job.outputs.model_output}}
+      model_input_path: ${{parent.jobs.train_model_job.outputs.model_output}}
       model_base_name: component_registered_lr_01
 
   create_rai_job:
@@ -40,7 +40,7 @@ jobs:
     inputs:
       title: With just the OSS
       task_type: classification
-      model_info_path: ${{parent.jobs.register-model-job.outputs.model_info_output_path}}
+      model_info_path: ${{parent.jobs.register_model_job.outputs.model_info_output_path}}
       train_dataset: ${{parent.inputs.my_training_data}}
       test_dataset: ${{parent.inputs.my_test_data}}
       target_column_name: ${{parent.inputs.target_column_name}}
@@ -51,13 +51,13 @@ jobs:
     component: azureml:rai_insights_explanation:VERSION_REPLACEMENT_STRING
     inputs:
       comment: Some random string
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
 
   causal_01:
     type: command
     component: azureml:rai_insights_causal:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       treatment_features: '["Age", "Sex"]'
       heterogeneity_features: '["Marital Status"]'
 
@@ -65,7 +65,7 @@ jobs:
     type: command
     component: azureml:rai_insights_counterfactual:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       total_CFs: 10
       desired_class: opposite
 
@@ -73,14 +73,14 @@ jobs:
     type: command
     component: azureml:rai_insights_erroranalysis:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       filter_features: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
 
   gather_01:
     type: command
     component: azureml:rai_insights_gather:VERSION_REPLACEMENT_STRING
     inputs:
-      constructor: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      constructor: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       insight_1: ${{parent.jobs.causal_01.outputs.causal}}
       insight_2: ${{parent.jobs.counterfactual_01.outputs.counterfactual}}
       insight_3: ${{parent.jobs.error_analysis_01.outputs.error_analysis}}

--- a/test/rai/pipeline_adult_analyse.yaml
+++ b/test/rai/pipeline_adult_analyse.yaml
@@ -19,7 +19,7 @@ settings:
   continue_on_step_failure: false
 
 jobs:
-  train-model-job:
+  train_model_job:
     type: command
     component: azureml:train_logistic_regression_for_rai:VERSION_REPLACEMENT_STRING
     inputs:
@@ -27,14 +27,14 @@ jobs:
       target_column_name: ${{parent.inputs.target_column_name}}
 
 
-  register-model-job:
+  register_model_job:
     type: command
     component: azureml:register_model:VERSION_REPLACEMENT_STRING
     inputs:
       model_input_path: ${{parent.jobs.train-model-job.outputs.model_output}}
       model_base_name: component_registered_lr_01
 
-  create-rai-job:
+  create_rai_job:
     type: command
     component: azureml:rai_insights_constructor:VERSION_REPLACEMENT_STRING
     inputs:

--- a/test/rai/pipeline_boston_analyse.yaml
+++ b/test/rai/pipeline_boston_analyse.yaml
@@ -16,7 +16,7 @@ inputs:
 compute: azureml:cpucluster
 
 jobs:
-  train-model-job:
+  train_model_job:
     type: command
     component: azureml:train_boston_for_rai:VERSION_REPLACEMENT_STRING
     inputs:
@@ -25,14 +25,14 @@ jobs:
       categorical_features: '[]'
       continuous_features: '["CRIM", "ZN", "INDUS", "CHAS", "NOX", "RM", "AGE","DIS", "RAD", "TAX", "PTRATIO", "B", "LSTAT"]'
 
-  register-model-job:
+  register_model_job:
     type: command
     component: azureml:register_model:VERSION_REPLACEMENT_STRING
     inputs:
       model_input_path: ${{parent.jobs.train-model-job.outputs.model_output}}
       model_base_name: component_registered_boston_01
 
-  create-rai-job:
+  create_rai_job:
     type: command
     component: azureml:rai_insights_constructor:VERSION_REPLACEMENT_STRING
     inputs:

--- a/test/rai/pipeline_boston_analyse.yaml
+++ b/test/rai/pipeline_boston_analyse.yaml
@@ -29,7 +29,7 @@ jobs:
     type: command
     component: azureml:register_model:VERSION_REPLACEMENT_STRING
     inputs:
-      model_input_path: ${{parent.jobs.train-model-job.outputs.model_output}}
+      model_input_path: ${{parent.jobs.train_model_job.outputs.model_output}}
       model_base_name: component_registered_boston_01
 
   create_rai_job:
@@ -38,7 +38,7 @@ jobs:
     inputs:
       title: Boston Housing Analysis
       task_type: regression
-      model_info_path: ${{parent.jobs.register-model-job.outputs.model_info_output_path}}
+      model_info_path: ${{parent.jobs.register_model_job.outputs.model_info_output_path}}
       train_dataset: ${{parent.inputs.my_training_data}}
       test_dataset: ${{parent.inputs.my_test_data}}
       target_column_name: ${{parent.inputs.target_column_name}}
@@ -49,13 +49,13 @@ jobs:
     component: azureml:rai_insights_explanation:VERSION_REPLACEMENT_STRING
     inputs:
       comment: Some random string
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
 
   causal_01:
     type: command
     component: azureml:rai_insights_causal:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       treatment_features: '["ZN", "NOX"]'
       heterogeneity_features: '[]'
       nuisance_model: linear
@@ -65,7 +65,7 @@ jobs:
     type: command
     component: azureml:rai_insights_counterfactual:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       total_CFs: 10
       desired_range: '[10, 300]'
       feature_importance: True
@@ -74,7 +74,7 @@ jobs:
     type: command
     component: azureml:rai_insights_erroranalysis:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       max_depth: 3
       filter_features: '[]'
 
@@ -82,7 +82,7 @@ jobs:
     type: command
     component: azureml:rai_insights_gather:VERSION_REPLACEMENT_STRING
     inputs:
-      constructor: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      constructor: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       insight_1: ${{parent.jobs.causal_01.outputs.causal}}
       insight_2: ${{parent.jobs.counterfactual_01.outputs.counterfactual}}
       insight_3: ${{parent.jobs.error_analysis_01.outputs.error_analysis}}


### PR DESCRIPTION
In up-coming SDK change, pipeline yaml file job name needs to be a python identifier, I only find two yaml files that need to change in RAI repo, please modify related files if I missed. 