### PR TITLE
Change "JobInput" to "Input" due to SDK change

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,9 +8,8 @@ import time
 
 from azure.identity import DefaultAzureCredential
 
-from azure.ml import MLClient
-from azure.ml import dsl
-from azure.ml.entities import JobInput, load_component
+from azure.ml import MLClient, dsl, Input
+from azure.ml.entities import load_component
 from azure.ml.entities import CommandComponent, PipelineJob
 
 from test.utilities_for_test import submit_and_wait
@@ -117,7 +116,7 @@ def registered_adult_model_id(ml_client, component_config):
     register_component = load_component(
         client=ml_client, name="register_model", version=version_string
     )
-    adult_train_pq = JobInput(path=f"adult_train_pq:{version_string}", mode="download")
+    adult_train_pq = Input(path=f"adult_train_pq:{version_string}", mode="download")
 
     @dsl.pipeline(
         compute="cpucluster",
@@ -159,7 +158,7 @@ def registered_boston_model_id(ml_client, component_config):
     register_component = load_component(
         client=ml_client, name="register_model", version=version_string
     )
-    boston_train_pq = JobInput(
+    boston_train_pq = Input(
         path=f"boston_train_pq:{version_string}", mode="download"
     )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -116,7 +116,7 @@ def registered_adult_model_id(ml_client, component_config):
     register_component = load_component(
         client=ml_client, name="register_model", version=version_string
     )
-    adult_train_pq = Input(path=f"adult_train_pq:{version_string}", mode="download")
+    adult_train_pq = Input(type="uri_file", path=f"adult_train_pq:{version_string}", mode="download")
 
     @dsl.pipeline(
         compute="cpucluster",
@@ -159,7 +159,7 @@ def registered_boston_model_id(ml_client, component_config):
         client=ml_client, name="register_model", version=version_string
     )
     boston_train_pq = Input(
-        path=f"boston_train_pq:{version_string}", mode="download"
+        type="uri_file", path=f"boston_train_pq:{version_string}", mode="download"
     )
 
     @dsl.pipeline(

--- a/test/rai/pipeline_adult_analyse.yaml
+++ b/test/rai/pipeline_adult_analyse.yaml
@@ -31,7 +31,7 @@ jobs:
     type: command
     component: azureml:register_model:VERSION_REPLACEMENT_STRING
     inputs:
-      model_input_path: ${{parent.jobs.train-model-job.outputs.model_output}}
+      model_input_path: ${{parent.jobs.train_model_job.outputs.model_output}}
       model_base_name: component_registered_lr_01
 
   create_rai_job:
@@ -40,7 +40,7 @@ jobs:
     inputs:
       title: With just the OSS
       task_type: classification
-      model_info_path: ${{parent.jobs.register-model-job.outputs.model_info_output_path}}
+      model_info_path: ${{parent.jobs.register_model_job.outputs.model_info_output_path}}
       train_dataset: ${{parent.inputs.my_training_data}}
       test_dataset: ${{parent.inputs.my_test_data}}
       target_column_name: ${{parent.inputs.target_column_name}}
@@ -51,13 +51,13 @@ jobs:
     component: azureml:rai_insights_explanation:VERSION_REPLACEMENT_STRING
     inputs:
       comment: Some random string
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
 
   causal_01:
     type: command
     component: azureml:rai_insights_causal:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       treatment_features: '["Age", "Sex"]'
       heterogeneity_features: '["Marital Status"]'
 
@@ -65,7 +65,7 @@ jobs:
     type: command
     component: azureml:rai_insights_counterfactual:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       total_CFs: 10
       desired_class: opposite
 
@@ -73,14 +73,14 @@ jobs:
     type: command
     component: azureml:rai_insights_erroranalysis:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       filter_features: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
 
   gather_01:
     type: command
     component: azureml:rai_insights_gather:VERSION_REPLACEMENT_STRING
     inputs:
-      constructor: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      constructor: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       insight_1: ${{parent.jobs.causal_01.outputs.causal}}
       insight_2: ${{parent.jobs.counterfactual_01.outputs.counterfactual}}
       insight_3: ${{parent.jobs.error_analysis_01.outputs.error_analysis}}

--- a/test/rai/pipeline_adult_analyse.yaml
+++ b/test/rai/pipeline_adult_analyse.yaml
@@ -19,7 +19,7 @@ settings:
   continue_on_step_failure: false
 
 jobs:
-  train-model-job:
+  train_model_job:
     type: command
     component: azureml:train_logistic_regression_for_rai:VERSION_REPLACEMENT_STRING
     inputs:
@@ -27,14 +27,14 @@ jobs:
       target_column_name: ${{parent.inputs.target_column_name}}
 
 
-  register-model-job:
+  register_model_job:
     type: command
     component: azureml:register_model:VERSION_REPLACEMENT_STRING
     inputs:
       model_input_path: ${{parent.jobs.train-model-job.outputs.model_output}}
       model_base_name: component_registered_lr_01
 
-  create-rai-job:
+  create_rai_job:
     type: command
     component: azureml:rai_insights_constructor:VERSION_REPLACEMENT_STRING
     inputs:

--- a/test/rai/pipeline_boston_analyse.yaml
+++ b/test/rai/pipeline_boston_analyse.yaml
@@ -16,7 +16,7 @@ inputs:
 compute: azureml:cpucluster
 
 jobs:
-  train-model-job:
+  train_model_job:
     type: command
     component: azureml:train_boston_for_rai:VERSION_REPLACEMENT_STRING
     inputs:
@@ -25,14 +25,14 @@ jobs:
       categorical_features: '[]'
       continuous_features: '["CRIM", "ZN", "INDUS", "CHAS", "NOX", "RM", "AGE","DIS", "RAD", "TAX", "PTRATIO", "B", "LSTAT"]'
 
-  register-model-job:
+  register_model_job:
     type: command
     component: azureml:register_model:VERSION_REPLACEMENT_STRING
     inputs:
       model_input_path: ${{parent.jobs.train-model-job.outputs.model_output}}
       model_base_name: component_registered_boston_01
 
-  create-rai-job:
+  create_rai_job:
     type: command
     component: azureml:rai_insights_constructor:VERSION_REPLACEMENT_STRING
     inputs:

--- a/test/rai/pipeline_boston_analyse.yaml
+++ b/test/rai/pipeline_boston_analyse.yaml
@@ -29,7 +29,7 @@ jobs:
     type: command
     component: azureml:register_model:VERSION_REPLACEMENT_STRING
     inputs:
-      model_input_path: ${{parent.jobs.train-model-job.outputs.model_output}}
+      model_input_path: ${{parent.jobs.train_model_job.outputs.model_output}}
       model_base_name: component_registered_boston_01
 
   create_rai_job:
@@ -38,7 +38,7 @@ jobs:
     inputs:
       title: Boston Housing Analysis
       task_type: regression
-      model_info_path: ${{parent.jobs.register-model-job.outputs.model_info_output_path}}
+      model_info_path: ${{parent.jobs.register_model_job.outputs.model_info_output_path}}
       train_dataset: ${{parent.inputs.my_training_data}}
       test_dataset: ${{parent.inputs.my_test_data}}
       target_column_name: ${{parent.inputs.target_column_name}}
@@ -49,13 +49,13 @@ jobs:
     component: azureml:rai_insights_explanation:VERSION_REPLACEMENT_STRING
     inputs:
       comment: Some random string
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
 
   causal_01:
     type: command
     component: azureml:rai_insights_causal:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       treatment_features: '["ZN", "NOX"]'
       heterogeneity_features: '[]'
       nuisance_model: linear
@@ -65,7 +65,7 @@ jobs:
     type: command
     component: azureml:rai_insights_counterfactual:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       total_CFs: 10
       desired_range: '[10, 300]'
       feature_importance: True
@@ -74,7 +74,7 @@ jobs:
     type: command
     component: azureml:rai_insights_erroranalysis:VERSION_REPLACEMENT_STRING
     inputs:
-      rai_insights_dashboard: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       max_depth: 3
       filter_features: '[]'
 
@@ -82,7 +82,7 @@ jobs:
     type: command
     component: azureml:rai_insights_gather:VERSION_REPLACEMENT_STRING
     inputs:
-      constructor: ${{parent.jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      constructor: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       insight_1: ${{parent.jobs.causal_01.outputs.causal}}
       insight_2: ${{parent.jobs.counterfactual_01.outputs.counterfactual}}
       insight_3: ${{parent.jobs.error_analysis_01.outputs.error_analysis}}

--- a/test/rai/test_causal_component.py
+++ b/test/rai/test_causal_component.py
@@ -81,10 +81,10 @@ class TestCausalComponent:
             }
 
         adult_train_pq = Input(
-            path=f"adult_train_pq:{version_string}", mode="download"
+            type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"
         )
         adult_test_pq = Input(
-            path=f"adult_test_pq:{version_string}", mode="download"
+            type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_causal_classification(
             target_column_name="income",
@@ -163,10 +163,10 @@ class TestCausalComponent:
             }
 
         adult_train_pq = Input(
-            path=f"boston_train_pq:{version_string}", mode="download"
+            type="uri_file", path=f"boston_train_pq:{version_string}", mode="download"
         )
         adult_test_pq = Input(
-            path=f"boston_test_pq:{version_string}", mode="download"
+            type="uri_file", path=f"boston_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_causal_regression(
             target_column_name="y",

--- a/test/rai/test_causal_component.py
+++ b/test/rai/test_causal_component.py
@@ -4,9 +4,7 @@
 
 import logging
 
-from azure.ml import MLClient
-from azure.ml import dsl
-from azure.ml.entities import JobInput
+from azure.ml import MLClient, dsl, Input
 
 from test.utilities_for_test import submit_and_wait
 
@@ -82,10 +80,10 @@ class TestCausalComponent:
                 "ux_json": gather_job.outputs.ux_json,
             }
 
-        adult_train_pq = JobInput(
+        adult_train_pq = Input(
             path=f"adult_train_pq:{version_string}", mode="download"
         )
-        adult_test_pq = JobInput(
+        adult_test_pq = Input(
             path=f"adult_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_causal_classification(
@@ -164,10 +162,10 @@ class TestCausalComponent:
                 "ux_json": gather_job.outputs.ux_json,
             }
 
-        adult_train_pq = JobInput(
+        adult_train_pq = Input(
             path=f"boston_train_pq:{version_string}", mode="download"
         )
-        adult_test_pq = JobInput(
+        adult_test_pq = Input(
             path=f"boston_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_causal_regression(

--- a/test/rai/test_counterfactual_component.py
+++ b/test/rai/test_counterfactual_component.py
@@ -4,9 +4,7 @@
 
 import logging
 
-from azure.ml import MLClient
-from azure.ml import dsl
-from azure.ml.entities import JobInput
+from azure.ml import MLClient, dsl, Input
 
 from test.utilities_for_test import submit_and_wait
 
@@ -74,10 +72,10 @@ class TestCounterfactualComponent:
                 "ux_json": gather_job.outputs.ux_json,
             }
 
-        adult_train_pq = JobInput(
+        adult_train_pq = Input(
             path=f"adult_train_pq:{version_string}", mode="download"
         )
-        adult_test_pq = JobInput(
+        adult_test_pq = Input(
             path=f"adult_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_counterfactual_classification(
@@ -149,10 +147,10 @@ class TestCounterfactualComponent:
                 "ux_json": gather_job.outputs.ux_json,
             }
 
-        adult_train_pq = JobInput(
+        adult_train_pq = Input(
             path=f"boston_train_pq:{version_string}", mode="download"
         )
-        adult_test_pq = JobInput(
+        adult_test_pq = Input(
             path=f"boston_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_counterfactual_regression(

--- a/test/rai/test_counterfactual_component.py
+++ b/test/rai/test_counterfactual_component.py
@@ -73,10 +73,10 @@ class TestCounterfactualComponent:
             }
 
         adult_train_pq = Input(
-            path=f"adult_train_pq:{version_string}", mode="download"
+            type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"
         )
         adult_test_pq = Input(
-            path=f"adult_test_pq:{version_string}", mode="download"
+            type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_counterfactual_classification(
             target_column_name="income",
@@ -148,10 +148,10 @@ class TestCounterfactualComponent:
             }
 
         adult_train_pq = Input(
-            path=f"boston_train_pq:{version_string}", mode="download"
+            type="uri_file", path=f"boston_train_pq:{version_string}", mode="download"
         )
         adult_test_pq = Input(
-            path=f"boston_test_pq:{version_string}", mode="download"
+            type="uri_file", path=f"boston_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_counterfactual_regression(
             target_column_name="y",

--- a/test/rai/test_erroranalysis_component.py
+++ b/test/rai/test_erroranalysis_component.py
@@ -73,10 +73,10 @@ class TestErrorAnalysisComponent:
             }
 
         adult_train_pq = Input(
-            path=f"adult_train_pq:{version_string}", mode="download"
+            type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"
         )
         adult_test_pq = Input(
-            path=f"adult_test_pq:{version_string}", mode="download"
+            type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_erroranalysis_classification(
             target_column_name="income",
@@ -144,10 +144,10 @@ class TestErrorAnalysisComponent:
             }
 
         adult_train_pq = Input(
-            path=f"boston_train_pq:{version_string}", mode="download"
+            type="uri_file", path=f"boston_train_pq:{version_string}", mode="download"
         )
         adult_test_pq = Input(
-            path=f"boston_test_pq:{version_string}", mode="download"
+            type="uri_file", path=f"boston_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_erroranalysis_regression(
             target_column_name="y",

--- a/test/rai/test_erroranalysis_component.py
+++ b/test/rai/test_erroranalysis_component.py
@@ -4,9 +4,7 @@
 
 import logging
 
-from azure.ml import MLClient
-from azure.ml import dsl
-from azure.ml.entities import JobInput
+from azure.ml import MLClient, dsl, Input
 
 from test.utilities_for_test import submit_and_wait
 
@@ -74,10 +72,10 @@ class TestErrorAnalysisComponent:
                 "ux_json": gather_job.outputs.ux_json,
             }
 
-        adult_train_pq = JobInput(
+        adult_train_pq = Input(
             path=f"adult_train_pq:{version_string}", mode="download"
         )
-        adult_test_pq = JobInput(
+        adult_test_pq = Input(
             path=f"adult_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_erroranalysis_classification(
@@ -145,10 +143,10 @@ class TestErrorAnalysisComponent:
                 "ux_json": gather_job.outputs.ux_json,
             }
 
-        adult_train_pq = JobInput(
+        adult_train_pq = Input(
             path=f"boston_train_pq:{version_string}", mode="download"
         )
-        adult_test_pq = JobInput(
+        adult_test_pq = Input(
             path=f"boston_test_pq:{version_string}", mode="download"
         )
         rai_pipeline = test_erroranalysis_regression(

--- a/test/rai/test_mini_sdk.py
+++ b/test/rai/test_mini_sdk.py
@@ -9,8 +9,7 @@ import tempfile
 
 from responsibleai import RAIInsights
 
-from azure.ml import MLClient
-from azure.ml.entities import JobInput
+from azure.ml import MLClient, Input
 from azure.ml.entities import CommandComponent, PipelineJob
 
 from azure_ml_rai import (
@@ -35,10 +34,10 @@ class TestMiniSDK:
         # Pipeline globals
         pipeline_inputs = {
             "target_column_name": "income",
-            "my_training_data": JobInput(
+            "my_training_data": Input(
                 dataset=f"adult_train_pq:{version_string}", mode="download"
             ),
-            "my_test_data": JobInput(
+            "my_test_data": Input(
                 dataset=f"adult_test_pq:{version_string}", mode="download"
             ),
         }

--- a/test/rai/test_rai_gather_errors.py
+++ b/test/rai/test_rai_gather_errors.py
@@ -4,9 +4,7 @@
 
 import logging
 
-from azure.ml import MLClient
-from azure.ml import dsl
-from azure.ml.entities import JobInput
+from azure.ml import MLClient, dsl, Input
 from azure.ml.entities import CommandComponent, PipelineJob
 
 from test.utilities_for_test import submit_and_wait
@@ -124,10 +122,10 @@ class TestRAIGatherErrors:
         # Assemble into a pipeline
         pipeline_job = test_constructor_mismatch(
             target_column_name="income",
-            train_data=JobInput(
+            train_data=Input(
                 path=f"adult_train_pq:{version_string}", mode="download"
             ),
-            test_data=JobInput(path=f"adult_test_pq:{version_string}", mode="download"),
+            test_data=Input(path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         # Send it
@@ -198,10 +196,10 @@ class TestRAIGatherErrors:
         # Assemble into a pipeline
         pipeline_job = test_multiple_tool_instances(
             target_column_name="income",
-            train_data=JobInput(
+            train_data=Input(
                 path=f"adult_train_pq:{version_string}", mode="download"
             ),
-            test_data=JobInput(path=f"adult_test_pq:{version_string}", mode="download"),
+            test_data=Input(path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         # Send it

--- a/test/rai/test_rai_gather_errors.py
+++ b/test/rai/test_rai_gather_errors.py
@@ -123,9 +123,9 @@ class TestRAIGatherErrors:
         pipeline_job = test_constructor_mismatch(
             target_column_name="income",
             train_data=Input(
-                path=f"adult_train_pq:{version_string}", mode="download"
+                type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"
             ),
-            test_data=Input(path=f"adult_test_pq:{version_string}", mode="download"),
+            test_data=Input(type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         # Send it
@@ -197,9 +197,9 @@ class TestRAIGatherErrors:
         pipeline_job = test_multiple_tool_instances(
             target_column_name="income",
             train_data=Input(
-                path=f"adult_train_pq:{version_string}", mode="download"
+                type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"
             ),
-            test_data=Input(path=f"adult_test_pq:{version_string}", mode="download"),
+            test_data=Input(type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         # Send it

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -183,9 +183,9 @@ class TestRAISmoke:
         pipeline_job = rai_classification_pipeline(
             target_column_name="income",
             train_data=Input(
-                path=f"adult_train_pq:{version_string}", mode="download"
+                type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"
             ),
-            test_data=Input(path=f"adult_test_pq:{version_string}", mode="download"),
+            test_data=Input(type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         # Send it
@@ -229,9 +229,9 @@ class TestRAISmoke:
         insights_pipeline_job = fetch_analyse_registered_model(
             model_id=registered_adult_model_id,
             train_data=Input(
-                path=f"adult_train_pq:{version_string}", mode="download"
+                type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"
             ),
-            test_data=Input(path=f"adult_test_pq:{version_string}", mode="download"),
+            test_data=Input(type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         # Send it

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -7,9 +7,8 @@ import logging
 import pathlib
 import time
 
-from azure.ml import dsl
-from azure.ml import MLClient
-from azure.ml.entities import JobInput, load_component
+from azure.ml import MLClient, dsl, Input
+from azure.ml.entities import load_component
 from azure.ml.entities import Job
 
 from test.utilities_for_test import submit_and_wait
@@ -183,10 +182,10 @@ class TestRAISmoke:
 
         pipeline_job = rai_classification_pipeline(
             target_column_name="income",
-            train_data=JobInput(
+            train_data=Input(
                 path=f"adult_train_pq:{version_string}", mode="download"
             ),
-            test_data=JobInput(path=f"adult_test_pq:{version_string}", mode="download"),
+            test_data=Input(path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         # Send it
@@ -229,10 +228,10 @@ class TestRAISmoke:
 
         insights_pipeline_job = fetch_analyse_registered_model(
             model_id=registered_adult_model_id,
-            train_data=JobInput(
+            train_data=Input(
                 path=f"adult_train_pq:{version_string}", mode="download"
             ),
-            test_data=JobInput(path=f"adult_test_pq:{version_string}", mode="download"),
+            test_data=Input(path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         # Send it

--- a/test/rai/test_tabular_datasets.py
+++ b/test/rai/test_tabular_datasets.py
@@ -44,8 +44,8 @@ class Testregister_tabular_dataset:
             return {}
 
         pipeline = my_pipeline(
-            Input(path=f"adult_train_pq:{version_string}", mode="download"),
-            Input(path=f"adult_test_pq:{version_string}", mode="download"),
+            Input(type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"),
+            Input(type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         conversion_pipeline_job = submit_and_wait(ml_client, pipeline)
@@ -77,7 +77,7 @@ class Testregister_tabular_dataset:
             return {}
 
         adult_train_pq = Input(
-            path=f"adult_train_pq:{version_string}", mode="download"
+            type="uri_file", path=f"adult_train_pq:{version_string}", mode="download"
         )
         pipeline = tabular_registration_pipeline(
             adult_train_pq, base_name=train_tabular_base
@@ -87,7 +87,7 @@ class Testregister_tabular_dataset:
         assert conversion_pipeline_job is not None
 
         adult_test_pq = Input(
-            path=f"adult_test_pq:{version_string}", mode="download"
+            type="uri_file", path=f"adult_test_pq:{version_string}", mode="download"
         )
         pipeline_2 = tabular_registration_pipeline(
             adult_test_pq, base_name=test_tabular_base

--- a/test/rai/test_tabular_datasets.py
+++ b/test/rai/test_tabular_datasets.py
@@ -6,9 +6,8 @@ import logging
 import pathlib
 import time
 
-from azure.ml import MLClient
-from azure.ml import dsl
-from azure.ml.entities import JobInput, load_component
+from azure.ml import MLClient, dsl, Input
+from azure.ml.entities import load_component
 from azure.ml.entities import CommandComponent, PipelineJob
 
 from test.utilities_for_test import submit_and_wait
@@ -45,8 +44,8 @@ class Testregister_tabular_dataset:
             return {}
 
         pipeline = my_pipeline(
-            JobInput(path=f"adult_train_pq:{version_string}", mode="download"),
-            JobInput(path=f"adult_test_pq:{version_string}", mode="download"),
+            Input(path=f"adult_train_pq:{version_string}", mode="download"),
+            Input(path=f"adult_test_pq:{version_string}", mode="download"),
         )
 
         conversion_pipeline_job = submit_and_wait(ml_client, pipeline)
@@ -77,7 +76,7 @@ class Testregister_tabular_dataset:
             )
             return {}
 
-        adult_train_pq = JobInput(
+        adult_train_pq = Input(
             path=f"adult_train_pq:{version_string}", mode="download"
         )
         pipeline = tabular_registration_pipeline(
@@ -87,7 +86,7 @@ class Testregister_tabular_dataset:
         conversion_pipeline_job = submit_and_wait(ml_client, pipeline)
         assert conversion_pipeline_job is not None
 
-        adult_test_pq = JobInput(
+        adult_test_pq = Input(
             path=f"adult_test_pq:{version_string}", mode="download"
         )
         pipeline_2 = tabular_registration_pipeline(


### PR DESCRIPTION
- Old version "JobInput" is now replaced by "Input".
- Input default type is "uri_folder", as test data are registered as "uri_file", type="uri_file" need to be specified in Input initialization.