### PR TITLE
Update 'release' package version

### DIFF
--- a/requirements-dev-releasepackage.txt
+++ b/requirements-dev-releasepackage.txt
@@ -1,7 +1,7 @@
 azure-common
 #--extra-index-url https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2-public
 --extra-index-url https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2
-azure-ml==0.0.61674560 # To be updated regularly
+azure-ml==0.0.61771647 # To be updated regularly
 colorama # Pending update
 pandas
 pyarrow


### PR DESCRIPTION
Since the 'dev' builds are green, update what is considered the 'release' version of the `azure-ml` SDK.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>