### PR TITLE
Tweak display name of causal component

### DIFF
--- a/src/responsibleai/component_causal.yaml
+++ b/src/responsibleai/component_causal.yaml
@@ -1,6 +1,6 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: rai_insights_causal
-display_name: Add Causal to a RAI Insights Dashboard
+display_name: Add Causal to RAI Insights Dashboard
 version: VERSION_REPLACEMENT_STRING
 type: command
 


### PR DESCRIPTION
An extraneous 'a' had inserted itself.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>