### PR TITLE
Add pipeline YAML for fetching models and converting datasets

### DIFF
--- a/test/rai/pipeline_fetch_tabular.yaml
+++ b/test/rai/pipeline_fetch_tabular.yaml
@@ -36,8 +36,8 @@ jobs:
       title: Minimal YAML
       task_type: classification
       model_info_path: ${{parent.jobs.fetch_model_job.outputs.model_info_output_path}}
-      train_dataset: ${{parent.convert_train_job.outputs.dataset_output_path}}
-      test_dataset: ${{parent.convert_test_job.outputs.dataset_output_path}}
+      train_dataset: ${{parent.jobs.convert_train_job.outputs.dataset_output_path}}
+      test_dataset: ${{parent.jobs.convert_test_job.outputs.dataset_output_path}}
       target_column_name: ${{parent.inputs.target_column_name}}
       categorical_column_names: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
 

--- a/test/rai/pipeline_fetch_tabular.yaml
+++ b/test/rai/pipeline_fetch_tabular.yaml
@@ -1,0 +1,56 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+experiment_name: AML_RAI_Fetch_Tabular_VERSION_REPLACEMENT_STRING
+type: pipeline
+
+inputs:
+  target_column_name: income
+
+settings:
+  default_datastore: azureml:workspaceblobstore
+  default_compute: azureml:cpucluster
+  continue_on_step_failure: false
+
+jobs:
+  fetch_model_job:
+    type: command
+    component: azureml:fetch_registered_model:VERSION_REPLACEMENT_STRING
+    inputs:
+      model_id: MODEL_ID_REPLACEMENT_STRING
+
+  convert_train_job:
+    type: command
+    component: azureml:convert_tabular_to_parquet:VERSION_REPLACEMENT_STRING
+    inputs:
+      tabular_dataset_name: TRAIN_TABULAR_REPLACEMENT_STRING
+
+  convert_test_job:
+    type: command
+    component: azureml:convert_tabular_to_parquet:VERSION_REPLACEMENT_STRING
+    inputs:
+      tabular_dataset_name: TEST_TABULAR_REPLACEMENT_STRING
+
+  create_rai_job:
+    type: command
+    component: azureml:rai_insights_constructor:VERSION_REPLACEMENT_STRING
+    inputs:
+      title: Minimal YAML
+      task_type: classification
+      model_info_path: ${{parent.jobs.fetch_model_job.outputs.model_info_output_path}}
+      train_dataset: ${{parent.convert_train_job.dataset_output_path}}
+      test_dataset: ${{parent.convert_test_job.dataset_output_path}}
+      target_column_name: ${{parent.inputs.target_column_name}}
+      categorical_column_names: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
+
+  explain_01:
+    type: command
+    component: azureml:rai_insights_explanation:VERSION_REPLACEMENT_STRING
+    inputs:
+      comment: Some random string
+      rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
+
+  gather_01:
+    type: command
+    component: azureml:rai_insights_gather:VERSION_REPLACEMENT_STRING
+    inputs:
+      constructor: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
+      insight_4: ${{parent.jobs.explain_01.outputs.explanation}}

--- a/test/rai/pipeline_fetch_tabular.yaml
+++ b/test/rai/pipeline_fetch_tabular.yaml
@@ -36,8 +36,8 @@ jobs:
       title: Minimal YAML
       task_type: classification
       model_info_path: ${{parent.jobs.fetch_model_job.outputs.model_info_output_path}}
-      train_dataset: ${{parent.convert_train_job.dataset_output_path}}
-      test_dataset: ${{parent.convert_test_job.dataset_output_path}}
+      train_dataset: ${{parent.convert_train_job.outputs.dataset_output_path}}
+      test_dataset: ${{parent.convert_test_job.outputs.dataset_output_path}}
       target_column_name: ${{parent.inputs.target_column_name}}
       categorical_column_names: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
 

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -24,8 +24,7 @@ class TestRAISmoke:
         pipeline_file = current_dir / "pipeline_adult_analyse.yaml"
         pipeline_processed_file = "pipeline_adult_analyse.processed.yaml"
 
-        replacements = {"VERSION_REPLACEMENT_STRING": str(
-            component_config["version"])}
+        replacements = {"VERSION_REPLACEMENT_STRING": str(component_config["version"])}
         process_file(pipeline_file, pipeline_processed_file, replacements)
 
         pipeline_job = Job.load(path=pipeline_processed_file)
@@ -37,8 +36,7 @@ class TestRAISmoke:
         pipeline_file = current_dir / "pipeline_boston_analyse.yaml"
         pipeline_processed_file = "pipeline_boston_analyse.processed.yaml"
 
-        replacements = {"VERSION_REPLACEMENT_STRING": str(
-            component_config["version"])}
+        replacements = {"VERSION_REPLACEMENT_STRING": str(component_config["version"])}
         process_file(pipeline_file, pipeline_processed_file, replacements)
 
         pipeline_job = Job.load(path=pipeline_processed_file)
@@ -209,8 +207,7 @@ class TestRAISmoke:
             ml_client.jobs.download(
                 pipeline_job.name, download_path=dashboard_path, output_name="dashboard"
             )
-            expected_path = pathlib.Path(
-                dashboard_path) / 'named-outputs' / 'dashboard'
+            expected_path = pathlib.Path(dashboard_path) / "named-outputs" / "dashboard"
             # This load is very fragile with respect to Python version and conda environment
             rai_i = RAIInsights.load(expected_path)
             assert rai_i is not None
@@ -262,6 +259,5 @@ class TestRAISmoke:
         )
 
         # Send it
-        insights_pipeline_job = submit_and_wait(
-            ml_client, insights_pipeline_job)
+        insights_pipeline_job = submit_and_wait(ml_client, insights_pipeline_job)
         assert insights_pipeline_job is not None

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -12,18 +12,10 @@ from azure.ml.entities import load_component
 from azure.ml.entities import Job
 from responsibleai import RAIInsights
 
-from test.utilities_for_test import submit_and_wait
+from test.utilities_for_test import submit_and_wait, process_file
 
 _logger = logging.getLogger(__file__)
 logging.basicConfig(level=logging.INFO)
-
-
-def process_file(input_file, output_file, replacements):
-    with open(input_file, "r") as infile, open(output_file, "w") as outfile:
-        for line in infile:
-            for f, r in replacements.items():
-                line = line.replace(f, r)
-            outfile.write(line)
 
 
 class TestRAISmoke:
@@ -32,7 +24,8 @@ class TestRAISmoke:
         pipeline_file = current_dir / "pipeline_adult_analyse.yaml"
         pipeline_processed_file = "pipeline_adult_analyse.processed.yaml"
 
-        replacements = {"VERSION_REPLACEMENT_STRING": str(component_config["version"])}
+        replacements = {"VERSION_REPLACEMENT_STRING": str(
+            component_config["version"])}
         process_file(pipeline_file, pipeline_processed_file, replacements)
 
         pipeline_job = Job.load(path=pipeline_processed_file)
@@ -44,7 +37,8 @@ class TestRAISmoke:
         pipeline_file = current_dir / "pipeline_boston_analyse.yaml"
         pipeline_processed_file = "pipeline_boston_analyse.processed.yaml"
 
-        replacements = {"VERSION_REPLACEMENT_STRING": str(component_config["version"])}
+        replacements = {"VERSION_REPLACEMENT_STRING": str(
+            component_config["version"])}
         process_file(pipeline_file, pipeline_processed_file, replacements)
 
         pipeline_job = Job.load(path=pipeline_processed_file)
@@ -215,7 +209,8 @@ class TestRAISmoke:
             ml_client.jobs.download(
                 pipeline_job.name, download_path=dashboard_path, output_name="dashboard"
             )
-            expected_path = pathlib.Path(dashboard_path) / 'named-outputs' / 'dashboard'
+            expected_path = pathlib.Path(
+                dashboard_path) / 'named-outputs' / 'dashboard'
             # This load is very fragile with respect to Python version and conda environment
             rai_i = RAIInsights.load(expected_path)
             assert rai_i is not None
@@ -267,5 +262,6 @@ class TestRAISmoke:
         )
 
         # Send it
-        insights_pipeline_job = submit_and_wait(ml_client, insights_pipeline_job)
+        insights_pipeline_job = submit_and_wait(
+            ml_client, insights_pipeline_job)
         assert insights_pipeline_job is not None

--- a/test/rai/test_tabular_datasets.py
+++ b/test/rai/test_tabular_datasets.py
@@ -8,9 +8,8 @@ import time
 
 from azure.ml import MLClient, dsl, Input
 from azure.ml.entities import load_component
-from azure.ml.entities import CommandComponent, PipelineJob
 
-from test.utilities_for_test import submit_and_wait
+from test.utilities_for_test import submit_and_wait, process_file
 
 _logger = logging.getLogger(__file__)
 logging.basicConfig(level=logging.INFO)
@@ -183,3 +182,8 @@ class Testregister_tabular_dataset:
 
         rai_pipeline_job = submit_and_wait(ml_client, rai_pipeline)
         assert rai_pipeline_job is not None
+
+        # ----
+
+        # Now do the same thing from a YAML file
+

--- a/test/rai/test_tabular_datasets.py
+++ b/test/rai/test_tabular_datasets.py
@@ -174,10 +174,13 @@ class Testregister_tabular_dataset:
                 "ux_json": rai_gather_job.outputs.ux_json,
             }
 
+        train_data_name = f"{train_tabular_base}_{epoch_secs}"
+        test_data_name = f"{test_tabular_base}_{epoch_secs}"
+
         rai_pipeline = use_tabular_rai(
             target_column_name="income",
-            train_data_name=f"{train_tabular_base}_{epoch_secs}",
-            test_data_name=f"{test_tabular_base}_{epoch_secs}",
+            train_data_name=train_data_name,
+            test_data_name=test_data_name,
         )
 
         rai_pipeline_job = submit_and_wait(ml_client, rai_pipeline)
@@ -186,4 +189,10 @@ class Testregister_tabular_dataset:
         # ----
 
         # Now do the same thing from a YAML file
-
+        replacements = {
+            "VERSION_REPLACEMENT_STRING": str(component_config["version"]),
+            "MODEL_ID_REPLACEMENT_STRING": registered_adult_model_id,
+            "TRAIN_TABULAR_REPLACEMENT_STRING": train_data_name,
+            "TEST_TABULAR_REPLACEMENT_STRING": test_data_name,
+        }
+        process_file(pipeline_file, pipeline_processed_file, replacements)

--- a/test/rai/test_tabular_datasets.py
+++ b/test/rai/test_tabular_datasets.py
@@ -194,7 +194,6 @@ class Testregister_tabular_dataset:
         pipeline_file = current_dir / "pipeline_fetch_tabular.yaml"
         pipeline_processed_file = "pipeline_fetch_tabular.processed.yaml"
 
-
         replacements = {
             "VERSION_REPLACEMENT_STRING": str(component_config["version"]),
             "MODEL_ID_REPLACEMENT_STRING": registered_adult_model_id,

--- a/test/rai/test_tabular_datasets.py
+++ b/test/rai/test_tabular_datasets.py
@@ -8,6 +8,7 @@ import time
 
 from azure.ml import MLClient, dsl, Input
 from azure.ml.entities import load_component
+from azure.ml.entities import Job
 
 from test.utilities_for_test import submit_and_wait, process_file
 
@@ -189,6 +190,11 @@ class Testregister_tabular_dataset:
         # ----
 
         # Now do the same thing from a YAML file
+        current_dir = pathlib.Path(__file__).parent.absolute()
+        pipeline_file = current_dir / "pipeline_fetch_tabular.yaml"
+        pipeline_processed_file = "pipeline_fetch_tabular.processed.yaml"
+
+
         replacements = {
             "VERSION_REPLACEMENT_STRING": str(component_config["version"]),
             "MODEL_ID_REPLACEMENT_STRING": registered_adult_model_id,
@@ -196,3 +202,7 @@ class Testregister_tabular_dataset:
             "TEST_TABULAR_REPLACEMENT_STRING": test_data_name,
         }
         process_file(pipeline_file, pipeline_processed_file, replacements)
+
+        pipeline_job = Job.load(path=pipeline_processed_file)
+
+        submit_and_wait(ml_client, pipeline_job)

--- a/test/utilities_for_test.py
+++ b/test/utilities_for_test.py
@@ -30,3 +30,11 @@ def submit_and_wait(
         _logger.error(str(created_job))
     assert created_job.status == expected_state
     return created_job
+
+
+def process_file(input_file, output_file, replacements):
+    with open(input_file, "r") as infile, open(output_file, "w") as outfile:
+        for line in infile:
+            for f, r in replacements.items():
+                line = line.replace(f, r)
+            outfile.write(line)


### PR DESCRIPTION
Extend an existing test to repeat the final experiment using a YAML. This is mainly so that we have YAML samples for the 'Fetch Registered Model" and "TabularDataset to Parquet" components.