### PR TITLE
Upper bound on SciKit-Learn to fix builds

### DIFF
--- a/requirements-dev-releasepackage.txt
+++ b/requirements-dev-releasepackage.txt
@@ -5,5 +5,5 @@ azure-ai-ml==0.0.62653692  # To be updated regularly
 colorama # Pending update
 pandas
 pyarrow
-scikit-learn
+scikit-learn<1.1 # See PR #1429 in responsible-ai-toolbox repo
 shap

--- a/requirements-dev-test.txt
+++ b/requirements-dev-test.txt
@@ -4,5 +4,5 @@ azure-ml
 colorama # Pending update
 pandas
 pyarrow
-scikit-learn
+scikit-learn<1.1 # See PR #1429 in responsible-ai-toolbox repo
 shap

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ azure-ai-ml
 colorama # Pending update
 pandas
 pyarrow
-scikit-learn
+scikit-learn<1.1 # See PR #1429 in responsible-ai-toolbox repo
 shap

--- a/requirements-for-testing.txt
+++ b/requirements-for-testing.txt
@@ -6,3 +6,4 @@ pytest
 pytest-xdist
 raiwidgets~=0.18.0
 responsibleai~=0.18.0
+scikit-learn<1.1 # See PR #1429 in responsible-ai-toolbox repo

--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -8,7 +8,7 @@ dependencies:
     - numpy
     - pandas
     - pyarrow
-    - scikit-learn
+    - scikit-learn<1.1 # See PR 1429 in responsible-ai-toolbox
     - mlflow
     - azureml-mlflow
     - responsibleai~=0.18.0

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -94,10 +94,10 @@ def test_responsibleaidashboard_programmer_regression_model_debugging(
     ] = f"rai_programmer_example_version_string = '{train_version_string}'"
     replacements[
         "train_data_path = 'data/programmers-train.parquet'"
-    ] = f'train_data_path = "{os.path.join(data_dir, train_filename)}"'
+    ] = f'train_data_path = r"{os.path.join(data_dir, train_filename)}"'
     replacements[
         "test_data_path = 'data/programmers-test.parquet'"
-    ] = f'test_data_path = "{os.path.join(data_dir, test_filename)}"'
+    ] = f'test_data_path = r"{os.path.join(data_dir, test_filename)}"'
 
     assay_one_notebook(nb_name, dict(), replacements)
 


### PR DESCRIPTION
The latest release of SciKit-Learn is causing trouble in the causal component. See the [PR in `responsible-ai-toolbox`](https://github.com/microsoft/responsible-ai-toolbox/pull/1429) for details. Until a new version of `responsibleai` is available, we have to apply the upper bound in this repo too.