### PR TITLE
fix typo in metric explanation text

### DIFF
--- a/src/responsibleai/rai_analyse/_score_card/regression_components.py
+++ b/src/responsibleai/rai_analyse/_score_card/regression_components.py
@@ -72,7 +72,7 @@ def get_data_explorer_page(data):
 
 def get_metric_explanation_text(mname, mvalue):
     text_lookup = {
-        "mean_squared_error": "{} is the average of the sqaured difference between the actual values and the predicted values.",
+        "mean_squared_error": "{} is the average of the squared difference between the actual values and the predicted values.",
         "mean_absolute_error": "{} is the average of the absolute error values.",
     }
     return text_lookup[mname].format(round(mvalue, 2))


### PR DESCRIPTION
fix typo in metric explanation text, sqaured should be squared