### PR TITLE
Protobuf upper bound

### DIFF
--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -10,6 +10,7 @@ dependencies:
     - pyarrow
     - scikit-learn<1.1 # See PR 1429 in responsible-ai-toolbox
     - mlflow
+    - protobuf<4 # Release
     - azureml-mlflow
     - responsibleai~=0.18.0
     - raiwidgets~=0.18.0

--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -10,7 +10,7 @@ dependencies:
     - pyarrow
     - scikit-learn<1.1 # See PR 1429 in responsible-ai-toolbox
     - mlflow
-    - protobuf<4 # Release
+    - protobuf<4 # Release has caused trouble 2022-05-26
     - azureml-mlflow
     - responsibleai~=0.18.0
     - raiwidgets~=0.18.0

--- a/src/responsibleai/docker_env/Dockerfile
+++ b/src/responsibleai/docker_env/Dockerfile
@@ -26,7 +26,8 @@ RUN pip install 'responsibleai~=0.18.1' \
                 'azureml-telemetry==1.41.0' \
                 'pdfkit==1.0.0' \
                 'plotly==5.6.0' \
-                'kaleido==0.2.1'
+                'kaleido==0.2.1' \
+                'protobuf<4'
 
 # no-deps install for domonic due to unresolable dependencies requirment on urllib3 and requests. 
 RUN pip install --no-deps 'charset-normalizer==2.0.12' \


### PR DESCRIPTION
The latest release of protobuf appears to be causing trouble for mlflow. Upper bound for now, pending fix (probably from `mlflow`).