### PR TITLE
Add pre release azure-ai-ml package to RAI docker file

### DIFF
--- a/src/responsibleai/docker_env/Dockerfile
+++ b/src/responsibleai/docker_env/Dockerfile
@@ -25,6 +25,8 @@ RUN pip install 'responsibleai~=0.18.1' \
                 'kaleido==0.2.1' \
                 'protobuf<4'
 
+RUN pip install --pre azure-ai-ml
+
 # no-deps install for domonic due to unresolable dependencies requirment on urllib3 and requests. 
 RUN pip install --no-deps 'charset-normalizer==2.0.12' \
                           'cssselect==1.1.0' \


### PR DESCRIPTION
This PR adds pre release version of azure-ai-ml package to RAI docker file. Azure-ai-ml package is required for UI side to connect RAI components to compute instance. So we add the azure-ai-ml package in the docker file.