### PR TITLE
update pipeline compute name

### DIFF
--- a/examples/CLI/pipeline_rai_adult.yaml
+++ b/examples/CLI/pipeline_rai_adult.yaml
@@ -15,7 +15,7 @@ inputs:
 
 settings:
   default_datastore: azureml:workspaceblobstore
-  default_compute: azureml:cpucluster
+  default_compute: azureml:cpu-cluster
   continue_on_step_failure: false
 
 jobs:


### PR DESCRIPTION
`cpu-cluster` is the standard name across the azureml examples. In this file, it is "cpucluster" and it causes the pipeline to break if you don't create a new cluster for it.

Changing name to cpu-cluster for consistency across azureml examples.