### PR TITLE
[fix] Update setup script to use conda instead of miniconda for workshop

### DIFF
--- a/quick-setup.bash
+++ b/quick-setup.bash
@@ -26,7 +26,7 @@ echo "{ \"version\":\"1\" }" > component_config.json
 echo
 
 echo "=-= Creating conda environment"
-source ~/miniconda3/etc/profile.d/conda.sh
+# source ~/miniconda3/etc/profile.d/conda.sh
 conda create -y -n ${condaEnv} python=3.8
 conda activate ${condaEnv}
 echo


### PR DESCRIPTION
Comment out line pointing source to miniconda to enable using the setup-script on a compute environment