### PR TITLE
Improve stack trace logging

### DIFF
--- a/requirements-for-testing.txt
+++ b/requirements-for-testing.txt
@@ -1,8 +1,10 @@
+azureml-telemetry
+azureml-core
+raiwidgets~=0.23.0
+responsibleai~=0.23.0
 nbformat
 nbval
 nteract-scrapbook
 papermill
 pytest
 pytest-xdist
-raiwidgets~=0.23.0
-responsibleai~=0.23.0

--- a/src/responsibleai/rai_analyse/_score_card/classification_components.py
+++ b/src/responsibleai/rai_analyse/_score_card/classification_components.py
@@ -356,11 +356,10 @@ def get_fairlearn_page(data):
             for c in data
         ]
         x_data = [
-            100 * (get_metric(
-                "selection_rate",
-                data[c]["y_test"],
-                data[c]["y_pred"]),
-                data[c]["pos_label"]
+            100
+            * (
+                get_metric("selection_rate", data[c]["y_test"], data[c]["y_pred"]),
+                data[c]["pos_label"],
             )
             for c in data
         ]

--- a/src/responsibleai/rai_analyse/_telemetry/_loggerfactory.py
+++ b/src/responsibleai/rai_analyse/_telemetry/_loggerfactory.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+import sys
 import logging
 import logging.handlers
 import traceback
@@ -141,7 +142,9 @@ def track(
                             raise
                         al.activity_info["exception_type"] = str(type(e))
                         al.activity_info["stacktrace"] = "\n".join(
-                            _extract_and_filter_stack(e, traceback.extract_stack())
+                            _extract_and_filter_stack(
+                                e, traceback.extract_tb(sys.exc_info()[2])
+                            )
                         )
                         raise
             except Exception:
@@ -164,7 +167,7 @@ def track(
 def _extract_and_filter_stack(e, traces):
     ret = [str(type(e))]
 
-    for trace in traces[:-1]:
+    for trace in traces:
         ret.append(f'File "{trace.filename}", line {trace.lineno} in {trace.name}')
         ret.append(f"  {trace.line}")
     return ret

--- a/test/rai/test_logger_factory.py
+++ b/test/rai/test_logger_factory.py
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+import sys
+import traceback
+from src.responsibleai.rai_analyse._telemetry._loggerfactory import (
+    _extract_and_filter_stack,
+)
+
+
+class TestStackTraceExtraction:
+    secret_string = "this_is_a_secret_that_should_not_be_printed"
+
+    def level_0(self):
+        self.level_1()
+
+    def level_1(self):
+        self.level_2()
+
+    def level_2(self):
+        raise ValueError(f"{self.secret_string}")
+
+    def test_expect_full_stack_trace_do_not_contain_secret_value(self):
+        extracted_stack = None
+        try:
+            self.level_0()
+        except Exception as e:
+            extracted_stack = _extract_and_filter_stack(
+                e, traceback.extract_tb(sys.exc_info()[2])
+            )
+
+        target_exception_snippet = [
+            "ValueError",
+            "self.level_0()",
+            "self.level_1()",
+            "self.level_2()",
+            "self.secret_string",
+        ]
+
+        assert extracted_stack is not None
+        stack_trace = " ".join(extracted_stack)
+        assert self.secret_string not in stack_trace
+        assert all([i in stack_trace for i in target_exception_snippet])


### PR DESCRIPTION
This extracts the full traceback, sample extracted traceback (with "\n".join() )

<class 'ValueError'>
File "main.py", line 28 in test_expect_full_stack_trace_do_not_contain_secret_value
  self.level_0()
File "main.py", line 17 in level_0
  self.level_1()
File "main.py", line 20 in level_1
  self.level_2()
File "main.py", line 23 in level_2
  raise ValueError(f"{self.secret_string}")
  
  
  Notice how exception message is retained without resolving, thus no runtime data are leaked.