### PR TITLE
Handle input json parsing error with hint to resolve issue.

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -24,6 +24,10 @@ jobs:
       - name: flake8
         run: flake8
 
+      - name: isort print diff
+        run: |
+          isort . --diff
+
       - name: Check sorted python imports using isort
         run: |
           isort . -c

--- a/src/responsibleai/rai_analyse/create_rai_insights.py
+++ b/src/responsibleai/rai_analyse/create_rai_insights.py
@@ -8,13 +8,14 @@ import os
 import shutil
 
 from _telemetry._loggerfactory import _LoggerFactory, track
-from arg_helpers import (boolean_parser, get_from_args,
+from arg_helpers import (boolean_parser,
                          json_empty_is_none_parser)
 from azureml.core import Run
 from constants import DashboardInfo, PropertyKeyValues
 from rai_component_utilities import (default_json_handler, fetch_model_id,
                                      get_test_dataset_id, get_train_dataset_id,
-                                     load_dataset, load_mlflow_model)
+                                     load_dataset, load_mlflow_model,
+                                     get_arg)
 from raiutils.exceptions import UserConfigValidationException
 from responsibleai.feature_metadata import FeatureMetadata
 
@@ -90,13 +91,13 @@ def create_constructor_arg_dict(args):
     """
     result = dict()
 
-    cat_col_names = get_from_args(
+    cat_col_names = get_arg(
         args, "categorical_column_names", custom_parser=json.loads, allow_none=True
     )
-    class_names = get_from_args(
+    class_names = get_arg(
         args, "classes", custom_parser=json_empty_is_none_parser, allow_none=True
     )
-    feature_metadata_dict = get_from_args(
+    feature_metadata_dict = get_arg(
         args, "feature_metadata", custom_parser=json.loads, allow_none=True
     )
     feature_metadata = FeatureMetadata()

--- a/src/responsibleai/rai_analyse/create_rai_insights.py
+++ b/src/responsibleai/rai_analyse/create_rai_insights.py
@@ -8,14 +8,13 @@ import os
 import shutil
 
 from _telemetry._loggerfactory import _LoggerFactory, track
-from arg_helpers import (boolean_parser,
-                         json_empty_is_none_parser)
+from arg_helpers import boolean_parser, json_empty_is_none_parser
 from azureml.core import Run
 from constants import DashboardInfo, PropertyKeyValues
 from rai_component_utilities import (default_json_handler, fetch_model_id,
-                                     get_test_dataset_id, get_train_dataset_id,
-                                     load_dataset, load_mlflow_model,
-                                     get_arg)
+                                     get_arg, get_test_dataset_id,
+                                     get_train_dataset_id, load_dataset,
+                                     load_mlflow_model)
 from raiutils.exceptions import UserConfigValidationException
 from responsibleai.feature_metadata import FeatureMetadata
 

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -16,12 +16,11 @@ from typing import Any, Dict, Optional
 import mlflow
 import mltable
 import pandas as pd
+from arg_helpers import get_from_args
 from azureml.core import Model, Run, Workspace
 from constants import DashboardInfo, PropertyKeyValues, RAIToolType
 from raiutils.exceptions import UserConfigValidationException
 from responsibleai.feature_metadata import FeatureMetadata
-
-from arg_helpers import get_from_args
 
 from responsibleai import RAIInsights
 from responsibleai import __version__ as responsibleai_version
@@ -429,6 +428,9 @@ def get_arg(args, arg_name: str, custom_parser, allow_none: bool) -> Any:
     try:
         return get_from_args(args, arg_name, custom_parser, allow_none)
     except ValueError as e:
-        raise UserConfigError(f"Unable to parse {arg_name} from {args}. Please check that {extracted} is valid input and that {arg_name} exists."
+        raise UserConfigError(
+            f"Unable to parse {arg_name} from {args}."
+            f"Please check that {args} is valid input and that {arg_name} exists."
             "For example, a json string with unquoted string value or key can cause this error."
-            f"Raw parsing error: {e}")
+            f"Raw parsing error: {e}"
+        )

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -21,6 +21,8 @@ from constants import DashboardInfo, PropertyKeyValues, RAIToolType
 from raiutils.exceptions import UserConfigValidationException
 from responsibleai.feature_metadata import FeatureMetadata
 
+from arg_helpers import get_from_args
+
 from responsibleai import RAIInsights
 from responsibleai import __version__ as responsibleai_version
 
@@ -421,3 +423,12 @@ def default_object_hook(dict):
         del dict[data_type]
         return FeatureMetadata(**dict)
     return dict
+
+
+def get_arg(args, arg_name: str, custom_parser, allow_none: bool) -> Any:
+    try:
+        return get_from_args(args, arg_name, custom_parser, allow_none)
+    except ValueError as e:
+        raise UserConfigError(f"Unable to parse {arg_name} from {args}. Please check that {extracted} is valid input and that {arg_name} exists."
+            "For example, a json string with unquoted string value or key can cause this error."
+            f"Raw parsing error: {e}")


### PR DESCRIPTION
Invalid json string in input argument can cause a json decode error. For example, a json array of
'["string1", "string2"]' can be misconstructed as '[string1, string2]' causing a json decode error from None.