### PR TITLE
RAI housing decision making notebook: Change metrics to regression metrics

### DIFF
--- a/examples/notebooks/responsibleaidashboard-housing-decision-making.ipynb
+++ b/examples/notebooks/responsibleaidashboard-housing-decision-making.ipynb
@@ -622,8 +622,8 @@
    "source": [
     "## Score card generation config\n",
     "For score card generation, we need some additional configuration in a separate json file. Here we configure the following model performance metrics for reporting:\n",
-    "- mean squared error\n",
-    "- precision"
+    "- mean absolute error\n",
+    "- mean squared error"
    ]
   },
   {
@@ -641,9 +641,7 @@
     "        \"ModelType\": \"Regression\",\n",
     "        \"ModelSummary\": \"<model summary>\"\n",
     "    },\n",
-    "    \"Metrics\" :{\n",
-    "        \"mean_squared_error\": {}\n",
-    "    }\n",
+    "    \"Metrics\": {\"mean_squared_error\": {}, \"mean_absolute_error\": {}},\n",
     "}\n",
     "\n",
     "score_card_config_filename = \"rai_housing_decision_score_card_config.json\"\n",


### PR DESCRIPTION
So far, the scorecard metrics were classification metrics leading to a validation error during execution. Changing to regression metrics fixes the problem.

Duplicate of https://github.com/Azure/azureml-examples/pull/2076
Couldn't open the PR from a branch off of this repo since I'm not part of the required group (yet). That's why it's from my fork. If that's a problem I'll create a new PR once I have access.