### PR TITLE
pin libffi to 3.3 to fix libgobject undefined symbol ffi_type_uint32 error in score card

### DIFF
--- a/src/responsibleai/docker_env/Dockerfile
+++ b/src/responsibleai/docker_env/Dockerfile
@@ -5,8 +5,10 @@ RUN apt-get -y update && apt-get -y install wkhtmltopdf
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-0.24
 
 # Create conda environment
+# Note libffi is pinned as it causes scorecard component to fail
+# when using the wkhtmltopdf package with libgobject error
 RUN conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
-    python=3.8 pip=21.3.1 -c anaconda -c conda-forge
+    python=3.8 pip=21.3.1 libffi=3.3 -c anaconda -c conda-forge
 
 # Prepend path to AzureML conda environment
 ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH


### PR DESCRIPTION
Score card component is failing in test "test_boston_pipeline_from_yaml" with the error:

```
Traceback (most recent call last):
  File "create_score_card.py", line 295, in <module>
    main(get_parser().parse_args())
  File "/mnt/azureml/cr/j/47aea72509c5452fb23c5a4cdefed485/exe/wd/_telemetry/_loggerfactory.py", line 149, in wrapper
    return func(*args, **kwargs)
  File "create_score_card.py", line 202, in main
    wf.generate_pdf()
  File "create_score_card.py", line 254, in generate_pdf
    to_pdf(
  File "/mnt/azureml/cr/j/47aea72509c5452fb23c5a4cdefed485/exe/wd/_score_card/common_components.py", line 841, in to_pdf
    pdfkit.from_string(
  File "/azureml-envs/responsibleai-0.24/lib/python3.8/site-packages/pdfkit/api.py", line 75, in from_string
    return r.to_pdf(output_path)
  File "/azureml-envs/responsibleai-0.24/lib/python3.8/site-packages/pdfkit/pdfkit.py", line 201, in to_pdf
    self.handle_error(exit_code, stderr)
  File "/azureml-envs/responsibleai-0.24/lib/python3.8/site-packages/pdfkit/pdfkit.py", line 158, in handle_error
    raise IOError("wkhtmltopdf exited with non-zero code {0}. error:\n{1}".format(exit_code, error_msg))
OSError: wkhtmltopdf exited with non-zero code 127. error:
/usr/bin/wkhtmltopdf: symbol lookup error: /lib/x86_64-linux-gnu/libgobject-2.0.so.0: undefined symbol: ffi_type_uint32, version LIBFFI_BASE_7.0
```

Based on a diff of previous jobs that have passed and failed, it seems the error consistently occurs when the environment has a newer version of libffi = 3.4.2 installed.  Pinning to the older libffi = 3.3 version seems to resolve the runtime error.  It seems the docker ubuntu OS installs a certain version of libgobject that is dynamically linked to libffi, and when a newer version of libffi is installed in the conda environment some symbols have been changed which causes the runtime error.

Relevant links:

https://mail.gnome.org/archives/gtk-list/2011-November/msg00003.html
https://medium.com/@Aenon/glib-symbol-lookup-bug-in-debian-or-ubuntu-def678dab5a6
https://github.com/keeweb/keeweb/issues/1563