### PR TITLE
check if error output is None

### DIFF
--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -128,11 +128,12 @@ def load_mlflow_model(
 
 
 def _classify_and_log_pip_install_error(elog):
-    if "Could not find a version that satisfies the requirement" in elog:
-        _logger.warning("Detected unsatisfiable version requirment.")
+    if elog is not None:
+        if "Could not find a version that satisfies the requirement" in elog:
+            _logger.warning("Detected unsatisfiable version requirment.")
 
-    if "package versions have conflicting dependencies" in elog:
-        _logger.warning("Detected dependency conflict error.")
+        if "package versions have conflicting dependencies" in elog:
+            _logger.warning("Detected dependency conflict error.")
 
 
 def load_mltable(mltable_path: str) -> pd.DataFrame:


### PR DESCRIPTION
Subprocess error.output could be None : https://docs.python.org/3/library/subprocess.html so when we are checking if the output contains a substring we get a type error. Check that the output is not None before checking the contents.

To address: [Bug 2271185](https://msdata.visualstudio.com/Vienna/_workitems/edit/2271185): [Live site bug]TypeError in microsoft_azureml_rai_tabular_insight_constructor