### PR TITLE
Fix <class 'KeyError'> "id" does not exists in input json error in  rai_component_utilities.py fetch_model_id()

### DIFF
--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -66,7 +66,10 @@ def fetch_model_id(model_info_path: str):
     model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
     with open(model_info_path, "r") as json_file:
         model_info = json.load(json_file)
-    return model_info[DashboardInfo.MODEL_ID_KEY]
+    if DashboardInfo.MODEL_ID_KEY not in model_info:
+        raise UserConfigError(f"Input json is invalid, expecting key {DashboardInfo.MODEL_ID_KEY} exists in the input json")
+    else:
+        return model_info[DashboardInfo.MODEL_ID_KEY]
 
 
 def load_mlflow_model(


### PR DESCRIPTION
Fix <class 'KeyError'> for File "/mnt/azureml/cr/j/[guid]/exe/wd/rai_component_utilities.py", line 69 in fetch_model_id
return model_info[DashboardInfo.MODEL_ID_KEY]

The root cause is the input json file is not in expected format, missing key "id".
The fix is check if the key exists before using it, and raise a error to indicate the issue