### PR TITLE
Fix <class 'KeyError'> invalid json input in rai_component_utilities.py fetch_model_id()

### DIFF
--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -68,7 +68,9 @@ def fetch_model_id(model_info_path: str):
     with open(model_info_path, "r") as json_file:
         model_info = json.load(json_file)
     if DashboardInfo.MODEL_ID_KEY not in model_info:
-        raise UserConfigError(f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} exists in the input json")
+        raise UserConfigError(
+            f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"
+        )
     else:
         return model_info[DashboardInfo.MODEL_ID_KEY]
 

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -67,7 +67,10 @@ def fetch_model_id(model_info_path: str):
     model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
     with open(model_info_path, "r") as json_file:
         model_info = json.load(json_file)
-    return model_info[DashboardInfo.MODEL_ID_KEY]
+    if DashboardInfo.MODEL_ID_KEY not in model_info:
+        raise UserConfigError(f"Invalid input json, expecting key {DashboardInfo.MODEL_ID_KEY} exists in the input json")
+    else:
+        return model_info[DashboardInfo.MODEL_ID_KEY]
 
 
 def load_mlflow_model(

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -68,7 +68,7 @@ def fetch_model_id(model_info_path: str):
     with open(model_info_path, "r") as json_file:
         model_info = json.load(json_file)
     if DashboardInfo.MODEL_ID_KEY not in model_info:
-        raise UserConfigError(f"Invalid input json, expecting key {DashboardInfo.MODEL_ID_KEY} exists in the input json")
+        raise UserConfigError(f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} exists in the input json")
     else:
         return model_info[DashboardInfo.MODEL_ID_KEY]
 

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -68,7 +68,7 @@ def fetch_model_id(model_info_path: str):
     with open(model_info_path, "r") as json_file:
         model_info = json.load(json_file)
     if DashboardInfo.MODEL_ID_KEY not in model_info:
-        raise UserConfigError(
+        raise UserConfigValidationException(
             f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"
         )
     else:

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -1,0 +1,29 @@
+import json
+import os
+import pytest
+
+from raiutils.exceptions import UserConfigValidationException
+
+class TestFetchModelId:
+    
+    @pytest.mark.skip(reason="Skipping this test for now due to import issues, will enable once fixed")
+    @pytest.mark.parametrize("model_info_path, model_info, expected_model_id", [("", {"id": "abc"}, "abc" )])
+    def test_fetch_model_id(self, model_info_path, model_info, expected_model_id):
+        from src.responsibleai.rai_analyse.constants import DashboardInfo
+        from src.responsibleai.rai_analyse.rai_component_utilities import fetch_model_id
+        model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
+        with open(model_info_path, "w") as json_file:
+            json.dump(model_info, json_file)
+        assert fetch_model_id(model_info_path) == expected_model_id
+
+    @pytest.mark.skip(reason="Skipping this test for now due to import issues, will enable once fixed")
+    @pytest.mark.parametrize("model_info_path, model_info", [("", {"otherKeys": "abc"} )])
+    def test_fetch_model_id(self, model_info_path, model_info):
+        from src.responsibleai.rai_analyse.constants import DashboardInfo
+        from src.responsibleai.rai_analyse.rai_component_utilities import fetch_model_id
+        model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
+        with open(model_info_path, "w") as json_file:
+            json.dump(model_info, json_file)
+        with pytest.raises(UserConfigValidationException, match= f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"):
+            fetch_model_id(model_info_path)
+    

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -25,7 +25,7 @@ class TestFetchModelId:
         model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
         with open(model_info_path, "w") as json_file:
             json.dump(model_info, json_file)
-        with pytest.raises(
-            UserConfigValidationException, match= f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"
+        with pytest.raises(UserConfigValidationException,
+            match= f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"
         ):
             fetch_model_id(model_info_path)

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -1,7 +1,7 @@
 import json
 import os
-import pytest
 
+import pytest
 from raiutils.exceptions import UserConfigValidationException
 
 
@@ -11,7 +11,8 @@ class TestFetchModelId:
     @pytest.mark.parametrize("model_info_path, model_info, expected_model_id", [("", {"id": "abc"}, "abc")])
     def test_fetch_model_id(self, model_info_path, model_info, expected_model_id):
         from src.responsibleai.rai_analyse.constants import DashboardInfo
-        from src.responsibleai.rai_analyse.rai_component_utilities import fetch_model_id
+        from src.responsibleai.rai_analyse.rai_component_utilities import \
+            fetch_model_id
         model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
         with open(model_info_path, "w") as json_file:
             json.dump(model_info, json_file)
@@ -21,7 +22,8 @@ class TestFetchModelId:
     @pytest.mark.parametrize("model_info_path, model_info", [("", {"otherKeys": "abc"})])
     def test_fetch_model_id_invalid_input(self, model_info_path, model_info):
         from src.responsibleai.rai_analyse.constants import DashboardInfo
-        from src.responsibleai.rai_analyse.rai_component_utilities import fetch_model_id
+        from src.responsibleai.rai_analyse.rai_component_utilities import \
+            fetch_model_id
         model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
         with open(model_info_path, "w") as json_file:
             json.dump(model_info, json_file)

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -25,6 +25,7 @@ class TestFetchModelId:
         model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
         with open(model_info_path, "w") as json_file:
             json.dump(model_info, json_file)
-        with pytest.raises(UserConfigValidationException,
-                           match=f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"):
+        with pytest.raises(
+            UserConfigValidationException,
+                match=f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"):
             fetch_model_id(model_info_path)

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -4,10 +4,11 @@ import pytest
 
 from raiutils.exceptions import UserConfigValidationException
 
+
 class TestFetchModelId:
-    
+
     @pytest.mark.skip(reason="Skipping this test for now due to import issues, will enable once fixed")
-    @pytest.mark.parametrize("model_info_path, model_info, expected_model_id", [("", {"id": "abc"}, "abc" )])
+    @pytest.mark.parametrize("model_info_path, model_info, expected_model_id", [("", {"id": "abc"}, "abc")])
     def test_fetch_model_id(self, model_info_path, model_info, expected_model_id):
         from src.responsibleai.rai_analyse.constants import DashboardInfo
         from src.responsibleai.rai_analyse.rai_component_utilities import fetch_model_id
@@ -17,12 +18,14 @@ class TestFetchModelId:
         assert fetch_model_id(model_info_path) == expected_model_id
 
     @pytest.mark.skip(reason="Skipping this test for now due to import issues, will enable once fixed")
-    @pytest.mark.parametrize("model_info_path, model_info", [("", {"otherKeys": "abc"} )])
-    def test_fetch_model_id(self, model_info_path, model_info):
+    @pytest.mark.parametrize("model_info_path, model_info", [("", {"otherKeys": "abc"})])
+    def test_fetch_model_id_invalid_input(self, model_info_path, model_info):
         from src.responsibleai.rai_analyse.constants import DashboardInfo
         from src.responsibleai.rai_analyse.rai_component_utilities import fetch_model_id
         model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
         with open(model_info_path, "w") as json_file:
             json.dump(model_info, json_file)
-        with pytest.raises(UserConfigValidationException, match= f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"):
+        with pytest.raises(
+            UserConfigValidationException, match= f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"
+        ):
             fetch_model_id(model_info_path)

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -26,4 +26,3 @@ class TestFetchModelId:
             json.dump(model_info, json_file)
         with pytest.raises(UserConfigValidationException, match= f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"):
             fetch_model_id(model_info_path)
-    

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -26,6 +26,5 @@ class TestFetchModelId:
         with open(model_info_path, "w") as json_file:
             json.dump(model_info, json_file)
         with pytest.raises(UserConfigValidationException,
-            match= f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"
-        ):
+                           match=f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"):
             fetch_model_id(model_info_path)


### PR DESCRIPTION
Fix <class 'KeyError'> for File "/mnt/azureml/cr/j/[guid]/exe/wd/rai_component_utilities.py", line 69 in fetch_model_id
return model_info[DashboardInfo.MODEL_ID_KEY]

The root cause is the input json file is not in expected format, missing key "id".
The fix is check if the key exists before using it, and raise a error to indicate the issue