### PR TITLE
Raise validation exceptions in score card to fix KeyErrors

### DIFF
--- a/src/responsibleai/rai_analyse/_score_card/_rai_insight_data.py
+++ b/src/responsibleai/rai_analyse/_score_card/_rai_insight_data.py
@@ -32,7 +32,12 @@ ordered_label_metrics = ["confusion_matrix", "false_positive", "false_negative"]
 
 
 def get_metric(metric, y_test, y_pred, **kwargs):
-    func = metric_func_map[metric]
+    if metric not in metric_func_map:
+        raise UserConfigValidationException(
+            f"Invalid metric, metric {metric} is not supported."
+        )
+    else:
+        func = metric_func_map[metric]
 
     if metric in pos_label_metrics:
         return func(y_test, y_pred, pos_label=kwargs["pos_label"])

--- a/src/responsibleai/rai_analyse/_score_card/common_components.py
+++ b/src/responsibleai/rai_analyse/_score_card/common_components.py
@@ -8,7 +8,6 @@ import plotly.graph_objects as go
 import plotly.io as pio
 from domonic.html import (a, div, h1, h3, img, li, p, span, table, tbody, td,
                           thead, tr, ul)
-
 from raiutils.exceptions import UserConfigValidationException
 
 

--- a/src/responsibleai/rai_analyse/_score_card/common_components.py
+++ b/src/responsibleai/rai_analyse/_score_card/common_components.py
@@ -9,6 +9,7 @@ import plotly.io as pio
 from domonic.html import (a, div, h1, h3, img, li, p, span, table, tbody, td,
                           thead, tr, ul)
 
+from raiutils.exceptions import UserConfigValidationException
 
 def get_full_html(htmlbody):
     return "<!DOCTYPE html><html><body><head>{}</head>{}</body></html>".format(
@@ -530,7 +531,12 @@ def get_box_plot(data):
 def get_model_overview(data):
     model_left_items = []
 
-    model_left_items.append(div(h3("Purpose"), p(data["ModelSummary"])))
+    if "ModelSummary" not in data:
+        raise UserConfigValidationException(
+            f"Invalid model config data, expecting key ModelSummary to exist in the model config data."
+        )
+    else:
+        model_left_items.append(div(h3("Purpose"), p(data["ModelSummary"])))
 
     if data["ModelType"] == "binary_classification":
         model_left_items.append(

--- a/src/responsibleai/rai_analyse/_score_card/common_components.py
+++ b/src/responsibleai/rai_analyse/_score_card/common_components.py
@@ -11,6 +11,7 @@ from domonic.html import (a, div, h1, h3, img, li, p, span, table, tbody, td,
 
 from raiutils.exceptions import UserConfigValidationException
 
+
 def get_full_html(htmlbody):
     return "<!DOCTYPE html><html><body><head>{}</head>{}</body></html>".format(
         get_css(), htmlbody
@@ -533,7 +534,7 @@ def get_model_overview(data):
 
     if "ModelSummary" not in data:
         raise UserConfigValidationException(
-            f"Invalid model config data, expecting key ModelSummary to exist in the model config data."
+            "Invalid model config data, expecting key ModelSummary to exist in the model config data."
         )
     else:
         model_left_items.append(div(h3("Purpose"), p(data["ModelSummary"])))


### PR DESCRIPTION
This PR adds two UserConfigValidationExceptions:
1. For [Bug 2489952](https://msdata.visualstudio.com/Vienna/_workitems/edit/2489952): [Live site bug] KeyError for func = metric_func_map[metric] in create_score_card, check if the metric is a key in metric_func_map.
2. For [Bug 2491905](https://msdata.visualstudio.com/Vienna/_workitems/edit/2491905): [Live site bug] <class 'KeyError'>for microsoft_azureml_rai_tabular_score_card component when get_model_overview, check if ModelSummary is a key in model_overview's data