### PR TITLE
Enable use_model_dependency flag by default for RAI sample notebooks

### DIFF
--- a/examples/notebooks/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/examples/notebooks/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -685,6 +685,7 @@
     "            test_dataset=test_data,\n",
     "            target_column_name=target_column_name,\n",
     "            feature_metadata='{\"dropped_features\": [\"s3\", \"s5\"]}',\n",
+    "            use_model_dependency=True,\n",
     "        )\n",
     "        create_rai_job.set_limits(timeout=120)\n",
     "\n",

--- a/examples/notebooks/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
+++ b/examples/notebooks/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
@@ -675,6 +675,7 @@
     "            train_dataset=train_data,\n",
     "            test_dataset=test_data,\n",
     "            target_column_name=target_column_name,\n",
+    "            use_model_dependency=True,\n",
     "        )\n",
     "        create_rai_job.set_limits(timeout=120)\n",
     "        \n",

--- a/examples/notebooks/responsibleaidashboard-housing-classification-model-debugging.ipynb
+++ b/examples/notebooks/responsibleaidashboard-housing-classification-model-debugging.ipynb
@@ -719,6 +719,7 @@
     "            target_column_name=target_column_name,\n",
     "            categorical_column_names=json.dumps(categorical_features),\n",
     "            classes=classes_in_target\n",
+    "            use_model_dependency=True,\n",
     "        )\n",
     "        create_rai_job.set_limits(timeout=120)\n",
     "        \n",

--- a/examples/notebooks/responsibleaidashboard-housing-classification-model-debugging.ipynb
+++ b/examples/notebooks/responsibleaidashboard-housing-classification-model-debugging.ipynb
@@ -718,7 +718,7 @@
     "            test_dataset=test_data,\n",
     "            target_column_name=target_column_name,\n",
     "            categorical_column_names=json.dumps(categorical_features),\n",
-    "            classes=classes_in_target\n",
+    "            classes=classes_in_target,\n",
     "            use_model_dependency=True,\n",
     "        )\n",
     "        create_rai_job.set_limits(timeout=120)\n",

--- a/examples/notebooks/responsibleaidashboard-housing-decision-making.ipynb
+++ b/examples/notebooks/responsibleaidashboard-housing-decision-making.ipynb
@@ -698,6 +698,7 @@
     "            test_dataset=test_data,\n",
     "            target_column_name=target_column_name,\n",
     "            categorical_column_names=json.dumps(categorical_features),\n",
+    "            use_model_dependency=True,\n",
     "        )\n",
     "        create_rai_job.set_limits(timeout=120)\n",
     "        \n",

--- a/examples/notebooks/responsibleaidashboard-programmer-regression-model-debugging.ipynb
+++ b/examples/notebooks/responsibleaidashboard-programmer-regression-model-debugging.ipynb
@@ -720,7 +720,7 @@
     "            train_dataset=train_data,\n",
     "            test_dataset=test_data,\n",
     "            target_column_name=target_column_name,\n",
-    "            categorical_column_names=categorical_columns\n",
+    "            categorical_column_names=categorical_columns,\n",
     "            use_model_dependency=True,\n",
     "        )\n",
     "        create_rai_job.set_limits(timeout=120)\n",

--- a/examples/notebooks/responsibleaidashboard-programmer-regression-model-debugging.ipynb
+++ b/examples/notebooks/responsibleaidashboard-programmer-regression-model-debugging.ipynb
@@ -721,6 +721,7 @@
     "            test_dataset=test_data,\n",
     "            target_column_name=target_column_name,\n",
     "            categorical_column_names=categorical_columns\n",
+    "            use_model_dependency=True,\n",
     "        )\n",
     "        create_rai_job.set_limits(timeout=120)\n",
     "        \n",


### PR DESCRIPTION
This PR enables use_model_dependency flag by default for RAI sample notebooks