### PR TITLE
Keep install log as byte array.

### DIFF
--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -130,7 +130,7 @@ def load_mlflow_model(
             )
             _logger.info(
                 "Dependency installation successful, logs: {}".format(
-                    install_log.decode("ascii")
+                    install_log
                 )
             )
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
conda install log invoked from subprocess.check_output() is a byte array. There are some cases where the byte array output contain non ascii characters (utf-8 decoding worked). To avoid decoding error, leaving the byte array as is for printing without decoding.

For example, a utf8 encoded byte array such as follows can still be printed:

utf8_bytearray = "source string \u20AC".encode("utf-8")

print(utf8_bytearray)

giving

b'source string \xe2\x82\xac'