### PR TITLE
Throw userconfigvalidation error if model input path not found

### DIFF
--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -72,8 +72,15 @@ def print_dir_tree(base_dir):
 
 def fetch_model_id(model_info_path: str):
     model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
-    with open(model_info_path, "r") as json_file:
-        model_info = json.load(json_file)
+    try:
+        json_file = open(model_info_path, "r")
+    except Exception as ex:
+        raise UserConfigValidationException(
+            f"Failed to open {model_info_path}. Please ensure the model path is correct.",
+            ex
+        )
+    model_info = json.load(json_file)
+    json_file.close()
     if DashboardInfo.MODEL_ID_KEY not in model_info:
         raise UserConfigValidationException(
             f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -74,10 +74,9 @@ def fetch_model_id(model_info_path: str):
     model_info_path = os.path.join(model_info_path, DashboardInfo.MODEL_INFO_FILENAME)
     try:
         json_file = open(model_info_path, "r")
-    except Exception as ex:
+    except Exception:
         raise UserConfigValidationException(
-            f"Failed to open {model_info_path}. Please ensure the model path is correct.",
-            ex
+            f"Failed to open {model_info_path}. Please ensure the model path is correct."
         )
     model_info = json.load(json_file)
     json_file.close()

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 import pytest
 from raiutils.exceptions import UserConfigValidationException
@@ -40,7 +41,8 @@ class TestFetchModelId:
             fetch_model_id(temp_dir)
 
     def test_fetch_model_id_invalid_model_path(self):
+        model_info_path = os.path.join("invalid_dir", DashboardInfo.MODEL_INFO_FILENAME)
         with pytest.raises(
             UserConfigValidationException,
-                match=r"Failed to open invalid_dir\\model_info.json. Please ensure the model path is correct."):
+                match=re.escape(f'Failed to open {model_info_path}. Please ensure the model path is correct.')):
             fetch_model_id("invalid_dir")

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -41,8 +41,8 @@ class TestFetchModelId:
             fetch_model_id(temp_dir)
 
     def test_fetch_model_id_invalid_model_path(self):
-        model_info_path = os.path.join("invalid_dir", DashboardInfo.MODEL_INFO_FILENAME)
+        model_info_path = os.path.join("invalid_model_path", DashboardInfo.MODEL_INFO_FILENAME)
         with pytest.raises(
             UserConfigValidationException,
                 match=re.escape(f'Failed to open {model_info_path}. Please ensure the model path is correct.')):
-            fetch_model_id("invalid_dir")
+            fetch_model_id("invalid_model_path")

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -38,11 +38,9 @@ class TestFetchModelId:
             UserConfigValidationException,
                 match=f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"):
             fetch_model_id(temp_dir)
-            
-    @pytest.mark.parametrize("model_info_")
-    def test_fetch_model_id_invalid_model_path(self, temp_dir):
-        model_info_path = os.path.join(temp_dir, DashboardInfo.MODEL_INFO_FILENAME)
+
+    def test_fetch_model_id_invalid_model_path(self):
         with pytest.raises(
             UserConfigValidationException,
-                match=f"Failed to open {model_info_path}. Please ensure the model path is correct."):
-            fetch_model_id("model_info_")
+                match=r"Failed to open invalid_dir\\model_info.json. Please ensure the model path is correct."):
+            fetch_model_id("invalid_dir")

--- a/test/rai/test_rai_component_utilities.py
+++ b/test/rai/test_rai_component_utilities.py
@@ -38,3 +38,11 @@ class TestFetchModelId:
             UserConfigValidationException,
                 match=f"Invalid input, expecting key {DashboardInfo.MODEL_ID_KEY} to exist in the input json"):
             fetch_model_id(temp_dir)
+            
+    @pytest.mark.parametrize("model_info_")
+    def test_fetch_model_id_invalid_model_path(self, temp_dir):
+        model_info_path = os.path.join(temp_dir, DashboardInfo.MODEL_INFO_FILENAME)
+        with pytest.raises(
+            UserConfigValidationException,
+                match=f"Failed to open {model_info_path}. Please ensure the model path is correct."):
+            fetch_model_id("model_info_")


### PR DESCRIPTION
throw user error when model input path is not found instead of file not found error; to address [Bug 2291174](https://msdata.visualstudio.com/Vienna/_workitems/edit/2291174): DPv2: FileNotFoundError seen during fetch_model_id()