### PR TITLE
Migrating subscription for PR gate

### DIFF
--- a/azuredevops/PR-Gate.yaml
+++ b/azuredevops/PR-Gate.yaml
@@ -60,7 +60,7 @@ parameters:
 
 variables:
 - name: SubscriptionName
-  value: "Project Vienna INT (589c7ae9-223e-45e3-a191-98433e0821a9) - RAI"
+  value: "Interpretability - Automation (a75ae43f-9f72-4699-ba66-d3a173cfe082) - RAI"
 - name: ConfigFileArtifact
   value: WorkspaceConfiguration
 


### PR DESCRIPTION
This pull request includes a single change to update the `SubscriptionName` variable in the `azuredevops/PR-Gate.yaml` file. The updated value reflects the correct subscription name used in the pipeline configuration.

* <a href="diffhunk://#diff-75fcda05f5dbdd7ea2a7a3e33ea6e6f1fe1f90627a8602c9f0b69ba95f32f206L63-R63">`azuredevops/PR-Gate.yaml`</a>: Updated the `SubscriptionName` variable to reflect the correct subscription name used in the pipeline configuration.