### PR TITLE
update RAI-vNext-Preview tabular image to be in sync with azureml-assets

### DIFF
--- a/azuredevops/Build-Update-Dev.yaml
+++ b/azuredevops/Build-Update-Dev.yaml
@@ -60,7 +60,7 @@ parameters:
 
 variables:
 - name: SubscriptionName
-  value: "Interpretability-Automation"
+  value: "Interpretability - Automation"
 - name: ConfigFileArtifact
   value: WorkspaceConfiguration
 

--- a/azuredevops/PR-Gate.yaml
+++ b/azuredevops/PR-Gate.yaml
@@ -60,7 +60,7 @@ parameters:
 
 variables:
 - name: SubscriptionName
-  value: "Interpretability-Automation"
+  value: "Interpretability - Automation"
 - name: ConfigFileArtifact
   value: WorkspaceConfiguration
 

--- a/src/responsibleai/docker_env/Dockerfile
+++ b/src/responsibleai/docker_env/Dockerfile
@@ -1,37 +1,28 @@
-FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:20231011.v1
-
-RUN apt-get -y update && apt-get -y install wkhtmltopdf
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai
 
-# Create conda environment
-# Note libffi is pinned as it causes scorecard component to fail
-# when using the wkhtmltopdf package with libgobject error
-RUN conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
-    python=3.8 pip=21.3.1 libffi=3.3 -c anaconda -c conda-forge
+# Install wkhtmltopdf for pdf rendering from html
+RUN apt-get -y update && apt-get -y install wkhtmltopdf
 
 # Prepend path to AzureML conda environment
 ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
 
-# Install pip dependencies
-RUN pip install 'responsibleai~=0.31.0' \
-                'pyarrow' \
-                'markupsafe<=2.0.1' \
-                'itsdangerous==2.0.1' \
-                'mlflow' \
-                'scikit-learn~=1.2' \
-                'pdfkit==1.0.0' \
-                'plotly==5.6.0' \
-                'kaleido==0.2.1' \
-                'protobuf<4' \
-                'mltable==1.4.1' \
-                'responsibleai-tabular-automl==0.8.0' \
-                'raiwidgets~=0.31.0' \
-                'https://publictestdatasets.blob.core.windows.net/packages/pypi/raiwidgets_big_data/raiwidgets_big_data-0.7.0-py3-none-any.whl'
+# Create conda environment
+COPY conda_dependencies.yaml .
+RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
+    rm conda_dependencies.yaml && \
+    conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
+    conda clean -a -y
 
-RUN pip install --pre 'azure-ai-ml~=1.14.0' 'azure-storage-blob<=12.13.0' 'numpy<1.24.0'
+RUN conda list
+# Conda install and pip install could happen side by side. Remove crypytography with vulnerability from conda
+RUN conda remove cryptography
 
-# no-deps install for domonic due to unresolable dependencies requirment on urllib3 and requests. 
+RUN pip install --pre 'azure-ai-ml' 'azure-storage-blob<=12.13.0' 'numpy<1.24.0'
+
+# no-deps install for domonic due to unresolvable dependencies requirment on urllib3 and requests.
+# score card rendering is using domonic only for the html elements composer which does not involve requests or urllib3
 RUN pip install --no-deps 'charset-normalizer==2.0.12' \
                           'cssselect==1.1.0' \
                           'elementpath==2.5.0' \
@@ -40,14 +31,27 @@ RUN pip install --no-deps 'charset-normalizer==2.0.12' \
                           'domonic==0.9.10'
 
 # Install azureml packages
-RUN pip install 'azureml-dataset-runtime==1.53.0' \
-                'azureml-core==1.53.0' \
-                'azureml-mlflow==1.53.0' \
-                'azureml-telemetry==1.53.0' \
+RUN pip install 'azureml-dataset-runtime==1.56.0' \
+                'azureml-core==1.56.0' \
+                'azureml-mlflow==1.56.0' \
+                'azureml-telemetry==1.56.0' \
                 'azureml-rai-utils==0.0.6'
+
+# azureml-dataset-runtime[fuse] upper bound for pyarrow is 11.0.0
+# so we install pyarrow in extra step to avoid conflict
+RUN pip install 'pyarrow>=14.0.1'
 
 # To resolve vulnerability issue
 RUN pip install 'Werkzeug==2.2.3'
+
+# To resolve vulnerability issue regarding crytography
+RUN pip install 'cryptography>=42.0.4'
+
+# TODO: remove rai-core-flask pin with next raiwidgets release
+RUN pip install 'rai-core-flask==0.7.4'
+
+# To resolve vulnerability issue
+RUN pip install 'gunicorn>=22.0.0'
 
 RUN pip freeze
 

--- a/src/responsibleai/docker_env/conda_dependencies.yaml
+++ b/src/responsibleai/docker_env/conda_dependencies.yaml
@@ -1,0 +1,21 @@
+name: responsibleai
+channels:
+  - conda-forge
+  - defaults
+  - anaconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - responsibleai~=0.34.1
+    - raiwidgets~=0.34.1
+    - markupsafe<=2.0.1
+    - itsdangerous==2.0.1
+    - mlflow
+    - scikit-learn~=1.2
+    - pdfkit==1.0.0
+    - plotly==5.6.0
+    - kaleido==0.2.1
+    - mltable==1.5.0
+    - responsibleai-tabular-automl==0.12.0
+    - https://publictestdatasets.blob.core.windows.net/packages/pypi/raiwidgets_big_data/raiwidgets_big_data-0.10.0-py3-none-any.whl


### PR DESCRIPTION
update RAI-vNext-Preview tabular image to be in sync with azureml-assets

This PR syncs the RAI-vNext-Preview tabular image definition to be in sync with the definition in azureml-assets repository:
https://github.com/Azure/azureml-assets/tree/main/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu

including the latest gunicorn vulnerability update:
https://github.com/Azure/azureml-assets/pull/2878

This should make it more reliable to make image updates and we can be more confident that the e2e tests in this repository validate the images before we deploy them, since there are minimal tests in the azureml-assets repository.