### PR TITLE
Fix cryptography vulnerability on RAI tabular image

### DIFF
--- a/src/responsibleai/docker_env/Dockerfile
+++ b/src/responsibleai/docker_env/Dockerfile
@@ -42,7 +42,7 @@ RUN pip install 'azureml-dataset-runtime==1.56.0' \
 RUN pip install 'pyarrow>=14.0.1'
 
 # To resolve vulnerability issue regarding crytography
-RUN pip install 'cryptography>=42.0.4'
+RUN pip install 'cryptography>=43.0.1'
 
 # TODO: remove rai-core-flask pin with next raiwidgets release
 RUN pip install 'rai-core-flask==0.7.6'


### PR DESCRIPTION
Fixes to RAI text & vision images equivalent to https://github.com/Azure/azureml-assets/pull/3356/files .