### PR TITLE
Update RAI tabular image to ubuntu 22.04

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 azure-common
-azure-ai-ml~=1.14.0
+azure-ai-ml~=1.25.0
 mltable~=1.4.1
 azureml_dataprep
 azureml_dataprep_rslex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 azure-common
-azure-ai-ml~=1.14.0
+azure-ai-ml~=1.25.0
 mltable~=1.4.1
 azureml_dataprep
 azureml_dataprep_rslex

--- a/src/responsibleai/docker_env/Dockerfile
+++ b/src/responsibleai/docker_env/Dockerfile
@@ -1,23 +1,21 @@
-FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest
-
-ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-tabular
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:latest
 
 # Install wkhtmltopdf for pdf rendering from html
 RUN apt-get -y update && apt-get -y install wkhtmltopdf
 
-# Prepend path to AzureML conda environment
-ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
+WORKDIR /
+ENV CONDA_PREFIX=/azureml-envs/responsibleai-tabular
+ENV CONDA_DEFAULT_ENV=$CONDA_PREFIX
 
 # Create conda environment
 COPY conda_dependencies.yaml .
-RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
-    rm conda_dependencies.yaml && \
-    conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
-    conda clean -a -y
+RUN conda env create -p $CONDA_PREFIX -f conda_dependencies.yaml -q && \
+    rm conda_dependencies.yaml
+
+# Prepend path to AzureML conda environment
+ENV PATH=$CONDA_PREFIX/bin:$PATH
 
 RUN conda list
-# Conda install and pip install could happen side by side. Remove crypytography with vulnerability from conda
-RUN conda remove cryptography
 
 RUN pip install --pre 'azure-ai-ml' 'azure-storage-blob<=12.13.0' 'numpy<1.24.0'
 
@@ -31,10 +29,10 @@ RUN pip install --no-deps 'charset-normalizer==2.0.12' \
                           'domonic==0.9.10'
 
 # Install azureml packages
-RUN pip install 'azureml-dataset-runtime==1.56.0' \
-                'azureml-core==1.56.0' \
-                'azureml-mlflow==1.56.0' \
-                'azureml-telemetry==1.56.0' \
+RUN pip install 'azureml-dataset-runtime' \
+                'azureml-core' \
+                'azureml-mlflow' \
+                'azureml-telemetry' \
                 'azureml-rai-utils==0.0.6'
 
 # azureml-dataset-runtime[fuse] upper bound for pyarrow is 11.0.0
@@ -52,7 +50,13 @@ RUN pip install 'gunicorn>=22.0.0'
 RUN pip install 'Werkzeug>=3.0.3'
 RUN pip install 'tqdm>=4.66.3'
 
+# clean conda and pip caches
+RUN conda run -p $CONDA_PREFIX pip cache purge && \
+    conda clean -a -y
+
+RUN rm -rf ~/.cache/pip
+
 RUN pip freeze
 
 # This is needed for mpi to locate libpython
-ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH $CONDA_PREFIX/lib:$LD_LIBRARY_PATH

--- a/src/responsibleai/docker_env/conda_dependencies.yaml
+++ b/src/responsibleai/docker_env/conda_dependencies.yaml
@@ -1,7 +1,6 @@
 name: responsibleai-tabular
 channels:
   - conda-forge
-  - defaults
   - anaconda
 dependencies:
   - python=3.9


### PR DESCRIPTION
Update RAI tabular image to ubuntu 22.04

Copilot summary:
This pull request includes several updates to the Docker environment and conda dependencies for the Responsible AI project. The changes focus on updating the base image, modifying environment variables, and cleaning up the installation process.

Updates to Docker environment:

* [`src/responsibleai/docker_env/Dockerfile`](diffhunk://#diff-bfcd7f4b46ae7e1d10eea473ad0d80eaa6383f8005c6505c5dc7943ac3ad1a94L1-L20): Updated the base image from `ubuntu20.04` to `ubuntu22.04` and adjusted environment variables to use `CONDA_PREFIX` instead of `AZUREML_CONDA_ENVIRONMENT_PATH`.
* [`src/responsibleai/docker_env/Dockerfile`](diffhunk://#diff-bfcd7f4b46ae7e1d10eea473ad0d80eaa6383f8005c6505c5dc7943ac3ad1a94L34-R35): Removed the installation of specific versions of AzureML packages, allowing them to use the latest versions available.
* [`src/responsibleai/docker_env/Dockerfile`](diffhunk://#diff-bfcd7f4b46ae7e1d10eea473ad0d80eaa6383f8005c6505c5dc7943ac3ad1a94R53-R62): Added steps to clean conda and pip caches to reduce the image size.

Updates to conda dependencies:

* [`src/responsibleai/docker_env/conda_dependencies.yaml`](diffhunk://#diff-a4d9c7f88eefd98ffb3bbc5dcc23c1eb0699c5e5497c1b95849746add6b1d0f0L4): Removed the `defaults` channel, simplifying the list of channels used for dependencies.